### PR TITLE
P1: terminal reliability + command registry + Spotify hardening

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -8,13 +8,19 @@ const {
   SPOTIFY_REFRESH_TOKEN: refreshToken,
 } = process.env;
 
-const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
 const TOKEN_ENDPOINT = `https://accounts.spotify.com/api/token`;
 const NOW_PLAYING_ENDPOINT = `https://api.spotify.com/v1/me/player/currently-playing`;
 const TOP_TRACKS_ENDPOINT = `https://api.spotify.com/v1/me/top/tracks`;
 const RECENTLY_PLAYED_ENDPOINT = `https://api.spotify.com/v1/me/player/recently-played`;
 
-const getAccessToken = async () => {
+function hasSpotifyEnv() {
+  return Boolean(clientId && clientSecret && refreshToken);
+}
+
+const getAccessToken = async (): Promise<string | null> => {
+  if (!hasSpotifyEnv()) return null;
+
+  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
   const response = await fetch(TOKEN_ENDPOINT, {
     method: "POST",
     headers: {
@@ -25,18 +31,24 @@ const getAccessToken = async () => {
       grant_type: "refresh_token",
       refresh_token: refreshToken as string,
     }),
+    cache: "no-store",
   });
 
-  return response.json();
+  if (!response.ok) return null;
+
+  const json = (await response.json()) as { access_token?: string };
+  return json.access_token ?? null;
 };
 
 export const getNowPlaying = async () => {
-  const { access_token } = await getAccessToken();
+  const accessToken = await getAccessToken();
+  if (!accessToken) return null;
 
   const response = await fetch(NOW_PLAYING_ENDPOINT, {
     headers: {
-      Authorization: `Bearer ${access_token}`,
+      Authorization: `Bearer ${accessToken}`,
     },
+    cache: "no-store",
   });
 
   if (!response.ok || response.status === 204) return null;
@@ -55,12 +67,14 @@ export const getNowPlaying = async () => {
 };
 
 export const getTopTracks = async () => {
-  const { access_token } = await getAccessToken();
+  const accessToken = await getAccessToken();
+  if (!accessToken) return null;
 
   const response = await fetch(TOP_TRACKS_ENDPOINT, {
     headers: {
-      Authorization: `Bearer ${access_token}`,
+      Authorization: `Bearer ${accessToken}`,
     },
+    cache: "no-store",
   });
 
   if (!response.ok) return null;
@@ -71,12 +85,14 @@ export const getTopTracks = async () => {
 };
 
 export const getRecentlyPlayed = async () => {
-  const { access_token } = await getAccessToken();
+  const accessToken = await getAccessToken();
+  if (!accessToken) return null;
 
   const response = await fetch(RECENTLY_PLAYED_ENDPOINT, {
     headers: {
-      Authorization: `Bearer ${access_token}`,
+      Authorization: `Bearer ${accessToken}`,
     },
+    cache: "no-store",
   });
 
   if (!response.ok) return null;

--- a/components/CommandsProvider.tsx
+++ b/components/CommandsProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Command } from "@/types";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useRef, useState } from "react";
 
 interface CommandsContextType {
   showWelcome: boolean;
@@ -26,26 +26,32 @@ export function useCommands() {
 export function CommandsProvider({ children }: { children: React.ReactNode }) {
   const [commands, setCommands] = useState<Command[]>([]);
   const [showWelcome, setShowWelcome] = useState(true);
+  const pendingScrollId = useRef<number | null>(null);
 
   const addCommand = (input: string) => {
-    if (commands.length === 0) {
-      setShowWelcome(false);
-    }
+    if (showWelcome) setShowWelcome(false);
 
+    const normalizedInput = input.trim().toLowerCase();
+    if (!normalizedInput) return;
+
+    const id =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
     const timestamp = new Date();
 
     setCommands((prev) => [
       ...prev,
       {
-        input: input.trimStart().trimEnd(),
+        id,
+        input: normalizedInput,
         timestamp,
       },
     ]);
 
-    setTimeout(() => {
-      const command = document.getElementById(
-        `cmd-${input}-${timestamp.getTime()}`
-      );
+    if (pendingScrollId.current) window.clearTimeout(pendingScrollId.current);
+    pendingScrollId.current = window.setTimeout(() => {
+      const command = document.getElementById(`cmd-${id}`);
 
       if (command) {
         command.scrollIntoView({ behavior: "smooth", inline: "start" });

--- a/components/MainScreen.tsx
+++ b/components/MainScreen.tsx
@@ -9,14 +9,10 @@ function MainScreen() {
   const { showWelcome, commands } = useCommands();
 
   return (
-    <Terminal>
-      {showWelcome && <CWelcome className="pb-2" />}
-      {commands.map((command, index) => (
-        <CommandItem
-          key={index}
-          input={command.input}
-          timestamp={command.timestamp}
-        />
+      <Terminal>
+        {showWelcome && <CWelcome className="pb-2" />}
+      {commands.map((command) => (
+        <CommandItem key={command.id} {...command} />
       ))}
     </Terminal>
   );

--- a/components/TerminalInput.tsx
+++ b/components/TerminalInput.tsx
@@ -2,7 +2,8 @@
 
 import { ArrowRight } from "lucide-react";
 import { useCommands } from "./CommandsProvider";
-import { COMMANDS, SPOTIFY_COMMANDS } from "@/lib/constants";
+import { COMMANDS } from "@/components/commands/registry";
+import { SPOTIFY_COMMANDS } from "@/components/commands/spotify-registry";
 import { useState } from "react";
 
 function TerminalInput() {

--- a/components/commands/CommandBash.tsx
+++ b/components/commands/CommandBash.tsx
@@ -1,8 +1,13 @@
-import { Command } from "@/types";
 import React from "react";
 import { AnimatedSpan } from "../Terminal";
 
-function CommandBash({ input, timestamp }: Command) {
+function CommandBash({
+  input,
+  timestamp,
+}: {
+  input: string;
+  timestamp: Date;
+}) {
   return (
     <AnimatedSpan>
       <div className="flex w-full items-center justify-between font-semibold text-sm gap-2">

--- a/components/commands/CommandItem.tsx
+++ b/components/commands/CommandItem.tsx
@@ -3,21 +3,14 @@
 import { Command } from "@/types";
 import CommandBash from "./CommandBash";
 import { useEffect, useMemo, useState } from "react";
-import CHelp from "./renders/CHelp";
 import CNotFound from "./renders/CNotFound";
 import { Loader } from "lucide-react";
-import CClear from "./renders/CClear";
-import CWelcome from "./renders/CWelcome";
-import CProjects from "./renders/CProjects";
-import CSkills from "./renders/CSkills";
-import CEducation from "./renders/CEducation";
-import CExperiences from "./renders/CExperiences";
-import CAbout from "./renders/CAbout";
 import CSpotify from "./renders/spotify/CSpotify";
-import CReset from "./renders/CReset";
+import { COMMAND_RENDERERS } from "./registry";
 
 function CommandWrapper({
   children,
+  id,
   input,
   timestamp,
 }: { children: React.ReactNode } & Command) {
@@ -32,46 +25,24 @@ function CommandWrapper({
   }, []);
 
   return (
-    <div
-      id={`cmd-${input}-${timestamp.getTime()}`}
-      className="flex flex-col gap-2 w-full pb-4"
-    >
+    <div id={`cmd-${id}`} className="flex flex-col gap-2 w-full pb-4">
       <CommandBash input={input} timestamp={timestamp} />
       {!show ? <Loader size={16} className="animate-spin" /> : children}
     </div>
   );
 }
 
-function CommandItem({ input, timestamp }: Command) {
+function CommandItem({ id, input, timestamp }: Command) {
   const content = useMemo(() => {
-    if (input.includes("spotify")) return <CSpotify input={input} />;
+    if (input.startsWith("spotify")) return <CSpotify input={input} />;
 
-    switch (input) {
-      case "help":
-        return <CHelp />;
-      case "clear":
-        return <CClear />;
-      case "reset":
-        return <CReset />;
-      case "welcome":
-        return <CWelcome />;
-      case "projects":
-        return <CProjects />;
-      case "skills":
-        return <CSkills />;
-      case "education":
-        return <CEducation />;
-      case "experiences":
-        return <CExperiences />;
-      case "about":
-        return <CAbout />;
-      default:
-        return <CNotFound input={input} />;
-    }
+    const renderer = COMMAND_RENDERERS[input];
+    if (!renderer) return <CNotFound input={input} />;
+    return renderer();
   }, [input]);
 
   return (
-    <CommandWrapper input={input} timestamp={timestamp}>
+    <CommandWrapper id={id} input={input} timestamp={timestamp}>
       {content}
     </CommandWrapper>
   );

--- a/components/commands/registry.tsx
+++ b/components/commands/registry.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { ReactNode } from "react";
+import CHelp from "./renders/CHelp";
+import CClear from "./renders/CClear";
+import CReset from "./renders/CReset";
+import CWelcome from "./renders/CWelcome";
+import CProjects from "./renders/CProjects";
+import CSkills from "./renders/CSkills";
+import CAbout from "./renders/CAbout";
+import CEducation from "./renders/CEducation";
+import CExperiences from "./renders/CExperiences";
+
+export type CommandDescriptor = {
+  command: string;
+  description: string;
+};
+
+type CommandDef = CommandDescriptor & {
+  render: () => ReactNode;
+};
+
+export const COMMAND_DEFS: CommandDef[] = [
+  {
+    command: "welcome",
+    description: "Display a welcome message and introduction",
+    render: () => <CWelcome />,
+  },
+  {
+    command: "help",
+    description: "Display a list of available commands and their descriptions",
+    render: () => <CHelp />,
+  },
+  {
+    command: "clear",
+    description: "Clear all previous commands and output from the terminal",
+    render: () => <CClear />,
+  },
+  {
+    command: "reset",
+    description: "Reset the terminal to the initial state",
+    render: () => <CReset />,
+  },
+  {
+    command: "projects",
+    description:
+      "Browse through my portfolio of personal and professional projects",
+    render: () => <CProjects />,
+  },
+  {
+    command: "skills",
+    description: "View my technical skills, tools and technologies I work with",
+    render: () => <CSkills />,
+  },
+  {
+    command: "about",
+    description: "Learn more about my background, interests and career goals",
+    render: () => <CAbout />,
+  },
+  {
+    command: "education",
+    description: "See my academic background and qualifications",
+    render: () => <CEducation />,
+  },
+  {
+    command: "experiences",
+    description: "Explore my professional work history and accomplishments",
+    render: () => <CExperiences />,
+  },
+];
+
+export const COMMANDS: CommandDescriptor[] = COMMAND_DEFS.map(
+  ({ command, description }) => ({ command, description })
+);
+
+export const COMMAND_RENDERERS: Record<string, () => ReactNode> =
+  Object.fromEntries(COMMAND_DEFS.map((c) => [c.command, c.render]));
+

--- a/components/commands/renders/CHelp.tsx
+++ b/components/commands/renders/CHelp.tsx
@@ -1,6 +1,6 @@
 import { useCommands } from "@/components/CommandsProvider";
 import { AnimatedSpan } from "@/components/Terminal";
-import { COMMANDS } from "@/lib/constants";
+import { COMMANDS } from "@/components/commands/registry";
 
 function CHelp() {
   const { addCommand } = useCommands();

--- a/components/commands/renders/CHelp.tsx
+++ b/components/commands/renders/CHelp.tsx
@@ -1,30 +1,8 @@
-import { useCommands } from "@/components/CommandsProvider";
-import { AnimatedSpan } from "@/components/Terminal";
 import { COMMANDS } from "@/components/commands/registry";
+import CommandList from "./CommandList";
 
 function CHelp() {
-  const { addCommand } = useCommands();
-
-  return (
-    <AnimatedSpan>
-      <p className="mb-3 text-chart-1 underline underline-offset-4">
-        Available commands:
-      </p>
-      <div className="flex flex-col w-full gap-1 max-w-full">
-        {COMMANDS.map((command) => (
-          <p key={command.command}>
-            <span
-              className="text-chart-2 hover:text-chart-2/80 transition-colors duration-200 cursor-pointer"
-              onClick={() => addCommand(command.command)}
-            >
-              {command.command}
-            </span>{" "}
-            - {command.description}
-          </p>
-        ))}
-      </div>
-    </AnimatedSpan>
-  );
+  return <CommandList items={COMMANDS} />;
 }
 
 export default CHelp;

--- a/components/commands/renders/CommandList.tsx
+++ b/components/commands/renders/CommandList.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useCommands } from "@/components/CommandsProvider";
+import { AnimatedSpan } from "@/components/Terminal";
+
+type Item = {
+  command: string;
+  description: string;
+};
+
+export default function CommandList({
+  title = "Available commands:",
+  items,
+  prefix = "",
+}: {
+  title?: string;
+  items: Item[];
+  prefix?: string;
+}) {
+  const { addCommand } = useCommands();
+
+  return (
+    <AnimatedSpan>
+      <p className="mb-3 text-chart-1 underline underline-offset-4">{title}</p>
+      <div className="flex flex-col w-full gap-1 max-w-full">
+        {items.map((item) => (
+          <p key={`${prefix}${item.command}`}>
+            <span
+              className="text-chart-2 hover:text-chart-2/80 transition-colors duration-200 cursor-pointer"
+              onClick={() => addCommand(`${prefix}${item.command}`)}
+            >
+              {prefix}
+              {item.command}
+            </span>{" "}
+            - {item.description}
+          </p>
+        ))}
+      </div>
+    </AnimatedSpan>
+  );
+}
+

--- a/components/commands/renders/spotify/CNowPlaying.tsx
+++ b/components/commands/renders/spotify/CNowPlaying.tsx
@@ -1,53 +1,43 @@
 import { getNowPlaying } from "@/app/actions";
 import { AnimatedSpan } from "@/components/Terminal";
-import { useQuery } from "@tanstack/react-query";
-import { Loader } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
+import SpotifyQuery from "./SpotifyQuery";
 
 function CNowPlaying() {
-  const { data, isLoading } = useQuery({
-    queryKey: ["now-playing"],
-    queryFn: getNowPlaying,
-    retry: false,
-  });
-
-  if (isLoading) return <Loader size={16} className="animate-spin" />;
-
-  if (!data)
-    return (
-      <p className="text-destructive">
-        Spotify is not configured or is unavailable.
-      </p>
-    );
-
-  if (!data.is_playing) return <p>Not playing 😕</p>;
-
   return (
-    <Link
-      href={data.item.external_urls.spotify}
-      target="_blank"
-      className="group w-fit"
-    >
-      <AnimatedSpan className="border flex w-fit items-center gap-3 rounded-lg p-3">
-        <Image
-          src={data.item.album.images[0].url}
-          alt={data.item.name}
-          width={50}
-          height={50}
-          className="rounded-sm"
-        />
-        <div>
-          <p className="text-sm font-semibold group-hover:text-chart-2 transition-colors duration-200">
-            {data.item.name}
-          </p>
-          <p className="text-muted-foreground">
-            {data.item.artists.map((a) => a.name).join(", ")}
-          </p>
-        </div>
-      </AnimatedSpan>
-    </Link>
+    <SpotifyQuery queryKey={["now-playing"]} queryFn={getNowPlaying}>
+      {(data) => {
+        if (!data.is_playing) return <p>Not playing 😕</p>;
+
+        return (
+          <Link
+            href={data.item.external_urls.spotify}
+            target="_blank"
+            className="group w-fit"
+          >
+            <AnimatedSpan className="border flex w-fit items-center gap-3 rounded-lg p-3">
+              <Image
+                src={data.item.album.images[0].url}
+                alt={data.item.name}
+                width={50}
+                height={50}
+                className="rounded-sm"
+              />
+              <div>
+                <p className="text-sm font-semibold group-hover:text-chart-2 transition-colors duration-200">
+                  {data.item.name}
+                </p>
+                <p className="text-muted-foreground">
+                  {data.item.artists.map((a) => a.name).join(", ")}
+                </p>
+              </div>
+            </AnimatedSpan>
+          </Link>
+        );
+      }}
+    </SpotifyQuery>
   );
 }
 

--- a/components/commands/renders/spotify/CNowPlaying.tsx
+++ b/components/commands/renders/spotify/CNowPlaying.tsx
@@ -15,7 +15,12 @@ function CNowPlaying() {
 
   if (isLoading) return <Loader size={16} className="animate-spin" />;
 
-  if (!data) return <p className="text-destructive">No data found.</p>;
+  if (!data)
+    return (
+      <p className="text-destructive">
+        Spotify is not configured or is unavailable.
+      </p>
+    );
 
   if (!data.is_playing) return <p>Not playing 😕</p>;
 

--- a/components/commands/renders/spotify/CRecentlyPlayed.tsx
+++ b/components/commands/renders/spotify/CRecentlyPlayed.tsx
@@ -15,7 +15,12 @@ function CRecentlyPlayed() {
 
   if (isLoading) return <Loader size={16} className="animate-spin" />;
 
-  if (!data) return <p className="text-destructive">No data found.</p>;
+  if (!data)
+    return (
+      <p className="text-destructive">
+        Spotify is not configured or is unavailable.
+      </p>
+    );
 
   return (
     <AnimatedSpan className="gap-2">

--- a/components/commands/renders/spotify/CRecentlyPlayed.tsx
+++ b/components/commands/renders/spotify/CRecentlyPlayed.tsx
@@ -1,61 +1,49 @@
 import { getRecentlyPlayed } from "@/app/actions";
 import { AnimatedSpan } from "@/components/Terminal";
-import { useQuery } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
-import { Loader } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import SpotifyQuery from "./SpotifyQuery";
 
 function CRecentlyPlayed() {
-  const { data, isLoading } = useQuery({
-    queryKey: ["recently-played"],
-    queryFn: getRecentlyPlayed,
-    retry: false,
-  });
-
-  if (isLoading) return <Loader size={16} className="animate-spin" />;
-
-  if (!data)
-    return (
-      <p className="text-destructive">
-        Spotify is not configured or is unavailable.
-      </p>
-    );
-
   return (
-    <AnimatedSpan className="gap-2">
-      {data.items.map((item) => (
-        <Link
-          key={item.played_at}
-          href={item.track.external_urls.spotify}
-          target="_blank"
-          className="flex items-center gap-2 py-1 group"
-        >
-          <Image
-            src={item.track.album.images[0].url}
-            alt={item.track.name}
-            width={50}
-            height={50}
-            className="rounded-sm"
-          />
-          <div className="flex flex-col sm:flex-row items-start sm:items-center flex-1 gap-1">
-            <div className="flex-1">
-              <p className="text-sm leading-4 line-clamp-1 font-semibold group-hover:text-chart-2 transition-colors duration-200">
-                {item.track.name}
-              </p>
-              <p className="text-muted-foreground line-clamp-1">
-                {item.track.artists.map((artist) => artist.name).join(", ")}
-              </p>
-            </div>
-            <p className="text-[0.7rem] text-muted-foreground">
-              {formatDistanceToNow(new Date(item.played_at), {
-                addSuffix: true,
-              })}
-            </p>
-          </div>
-        </Link>
-      ))}
-    </AnimatedSpan>
+    <SpotifyQuery queryKey={["recently-played"]} queryFn={getRecentlyPlayed}>
+      {(data) => (
+        <AnimatedSpan className="gap-2">
+          {data.items.map((item) => (
+            <Link
+              key={item.played_at}
+              href={item.track.external_urls.spotify}
+              target="_blank"
+              className="flex items-center gap-2 py-1 group"
+            >
+              <Image
+                src={item.track.album.images[0].url}
+                alt={item.track.name}
+                width={50}
+                height={50}
+                className="rounded-sm"
+              />
+              <div className="flex flex-col sm:flex-row items-start sm:items-center flex-1 gap-1">
+                <div className="flex-1">
+                  <p className="text-sm leading-4 line-clamp-1 font-semibold group-hover:text-chart-2 transition-colors duration-200">
+                    {item.track.name}
+                  </p>
+                  <p className="text-muted-foreground line-clamp-1">
+                    {item.track.artists.map((artist) => artist.name).join(", ")}
+                  </p>
+                </div>
+                <p className="text-[0.7rem] text-muted-foreground">
+                  {formatDistanceToNow(new Date(item.played_at), {
+                    addSuffix: true,
+                  })}
+                </p>
+              </div>
+            </Link>
+          ))}
+        </AnimatedSpan>
+      )}
+    </SpotifyQuery>
   );
 }
 

--- a/components/commands/renders/spotify/CSpotify.tsx
+++ b/components/commands/renders/spotify/CSpotify.tsx
@@ -1,9 +1,7 @@
 import { useMemo } from "react";
-import CNowPlaying from "./CNowPlaying";
 import CNotFound from "../CNotFound";
 import CSpotifyHelp from "./CSpotifyHelp";
-import CTopTracks from "./CTopTracks";
-import CRecentlyPlayed from "./CRecentlyPlayed";
+import { SPOTIFY_COMMAND_RENDERERS } from "@/components/commands/spotify-registry";
 
 function CSpotify({ input }: { input: string }) {
   const content = useMemo(() => {
@@ -11,16 +9,15 @@ function CSpotify({ input }: { input: string }) {
 
     if (command === "spotify" && !arg) return <CSpotifyHelp />;
 
-    switch (arg) {
-      case "now":
-        return <CNowPlaying />;
-      case "top":
-        return <CTopTracks />;
-      case "history":
-        return <CRecentlyPlayed />;
-      default:
-        return <CNotFound input={input} />;
-    }
+    if (!arg) return <CSpotifyHelp />;
+
+    const renderer =
+      SPOTIFY_COMMAND_RENDERERS[
+        arg as keyof typeof SPOTIFY_COMMAND_RENDERERS
+      ];
+    if (!renderer) return <CNotFound input={input} />;
+
+    return renderer();
   }, [input]);
 
   return content;

--- a/components/commands/renders/spotify/CSpotifyHelp.tsx
+++ b/components/commands/renders/spotify/CSpotifyHelp.tsx
@@ -1,6 +1,6 @@
 import { useCommands } from "@/components/CommandsProvider";
 import { AnimatedSpan } from "@/components/Terminal";
-import { SPOTIFY_COMMANDS } from "@/lib/constants";
+import { SPOTIFY_COMMANDS } from "@/components/commands/spotify-registry";
 
 function CSpotifyHelp() {
   const { addCommand } = useCommands();

--- a/components/commands/renders/spotify/CSpotifyHelp.tsx
+++ b/components/commands/renders/spotify/CSpotifyHelp.tsx
@@ -1,30 +1,8 @@
-import { useCommands } from "@/components/CommandsProvider";
-import { AnimatedSpan } from "@/components/Terminal";
 import { SPOTIFY_COMMANDS } from "@/components/commands/spotify-registry";
+import CommandList from "../CommandList";
 
 function CSpotifyHelp() {
-  const { addCommand } = useCommands();
-
-  return (
-    <AnimatedSpan>
-      <p className="mb-3 text-chart-1 underline underline-offset-4">
-        Available commands:
-      </p>
-      <div className="flex flex-col w-full gap-1 max-w-full">
-        {SPOTIFY_COMMANDS.map((command) => (
-          <p key={command.command}>
-            <span
-              className="text-chart-2 hover:text-chart-2/80 transition-colors duration-200 cursor-pointer"
-              onClick={() => addCommand(`spotify ${command.command}`)}
-            >
-              spotify {command.command}
-            </span>{" "}
-            - {command.description}
-          </p>
-        ))}
-      </div>
-    </AnimatedSpan>
-  );
+  return <CommandList items={SPOTIFY_COMMANDS} prefix="spotify " />;
 }
 
 export default CSpotifyHelp;

--- a/components/commands/renders/spotify/CTopTracks.tsx
+++ b/components/commands/renders/spotify/CTopTracks.tsx
@@ -14,7 +14,12 @@ function CTopTracks() {
 
   if (isLoading) return <Loader size={16} className="animate-spin" />;
 
-  if (!data) return <p className="text-destructive">No data found.</p>;
+  if (!data)
+    return (
+      <p className="text-destructive">
+        Spotify is not configured or is unavailable.
+      </p>
+    );
 
   return (
     <AnimatedSpan>

--- a/components/commands/renders/spotify/CTopTracks.tsx
+++ b/components/commands/renders/spotify/CTopTracks.tsx
@@ -1,82 +1,70 @@
 import { getTopTracks } from "@/app/actions";
 import { AnimatedSpan } from "@/components/Terminal";
-import { useQuery } from "@tanstack/react-query";
-import { Loader } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import SpotifyQuery from "./SpotifyQuery";
 
 function CTopTracks() {
-  const { data, isLoading } = useQuery({
-    queryKey: ["top-tracks"],
-    queryFn: getTopTracks,
-    retry: false,
-  });
-
-  if (isLoading) return <Loader size={16} className="animate-spin" />;
-
-  if (!data)
-    return (
-      <p className="text-destructive">
-        Spotify is not configured or is unavailable.
-      </p>
-    );
-
   return (
-    <AnimatedSpan>
-      <table className="overflow-x-auto max-w-full">
-        <thead>
-          <tr className="text-muted-foreground uppercase text-xs">
-            <th className="pb-2">Rank</th>
-            <th className="text-left px-4 pb-2">Track</th>
-            <th className="text-left pb-2">Album</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data?.items.map((item, index) => (
-            <tr key={item.id}>
-              <td>{index + 1}</td>
-              <td className="px-4">
-                <Link
-                  href={item.external_urls.spotify}
-                  target="_blank"
-                  className="flex items-center gap-2 py-1 group"
-                >
-                  <Image
-                    src={item.album.images[0].url}
-                    alt={item.name}
-                    width={50}
-                    height={50}
-                    className="rounded-sm"
-                  />
-                  <div>
-                    <p className="text-sm leading-4 line-clamp-2 font-semibold group-hover:text-chart-2 transition-colors duration-200">
-                      {item.name}
-                    </p>
-                    <p className="text-muted-foreground">
-                      {item.artists[0].name}
-                    </p>
-                  </div>
-                </Link>
-              </td>
-              <td>
-                <div>
-                  <Link
-                    href={item.album.external_urls.spotify}
-                    target="_blank"
-                    className="hover:text-chart-2 leading-4 font-semibold line-clamp-2 text-sm transition-colors duration-200"
-                  >
-                    {item.album.name}
-                  </Link>
-                  <p className="text-muted-foreground">
-                    {new Date(item.album.release_date).getFullYear()}
-                  </p>
-                </div>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </AnimatedSpan>
+    <SpotifyQuery queryKey={["top-tracks"]} queryFn={getTopTracks}>
+      {(data) => (
+        <AnimatedSpan>
+          <table className="overflow-x-auto max-w-full">
+            <thead>
+              <tr className="text-muted-foreground uppercase text-xs">
+                <th className="pb-2">Rank</th>
+                <th className="text-left px-4 pb-2">Track</th>
+                <th className="text-left pb-2">Album</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.map((item, index) => (
+                <tr key={item.id}>
+                  <td>{index + 1}</td>
+                  <td className="px-4">
+                    <Link
+                      href={item.external_urls.spotify}
+                      target="_blank"
+                      className="flex items-center gap-2 py-1 group"
+                    >
+                      <Image
+                        src={item.album.images[0].url}
+                        alt={item.name}
+                        width={50}
+                        height={50}
+                        className="rounded-sm"
+                      />
+                      <div>
+                        <p className="text-sm leading-4 line-clamp-2 font-semibold group-hover:text-chart-2 transition-colors duration-200">
+                          {item.name}
+                        </p>
+                        <p className="text-muted-foreground">
+                          {item.artists[0].name}
+                        </p>
+                      </div>
+                    </Link>
+                  </td>
+                  <td>
+                    <div>
+                      <Link
+                        href={item.album.external_urls.spotify}
+                        target="_blank"
+                        className="hover:text-chart-2 leading-4 font-semibold line-clamp-2 text-sm transition-colors duration-200"
+                      >
+                        {item.album.name}
+                      </Link>
+                      <p className="text-muted-foreground">
+                        {new Date(item.album.release_date).getFullYear()}
+                      </p>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </AnimatedSpan>
+      )}
+    </SpotifyQuery>
   );
 }
 

--- a/components/commands/renders/spotify/SpotifyQuery.tsx
+++ b/components/commands/renders/spotify/SpotifyQuery.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useQuery, type QueryKey } from "@tanstack/react-query";
+import { Loader } from "lucide-react";
+import type { ReactNode } from "react";
+import SpotifyUnavailable from "./SpotifyUnavailable";
+
+export default function SpotifyQuery<T>({
+  queryKey,
+  queryFn,
+  children,
+  refetchInterval,
+}: {
+  queryKey: QueryKey;
+  queryFn: () => Promise<T | null>;
+  children: (data: T) => ReactNode;
+  refetchInterval?: number;
+}) {
+  const { data, isLoading } = useQuery({
+    queryKey,
+    queryFn,
+    refetchInterval,
+    retry: false,
+  });
+
+  if (isLoading) return <Loader size={16} className="animate-spin" />;
+  if (!data) return <SpotifyUnavailable />;
+
+  return children(data);
+}
+

--- a/components/commands/renders/spotify/SpotifyUnavailable.tsx
+++ b/components/commands/renders/spotify/SpotifyUnavailable.tsx
@@ -1,0 +1,7 @@
+export default function SpotifyUnavailable() {
+  return (
+    <p className="text-destructive">
+      Spotify is not configured or is unavailable.
+    </p>
+  );
+}

--- a/components/commands/spotify-registry.tsx
+++ b/components/commands/spotify-registry.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import type { ReactNode } from "react";
+import CNowPlaying from "./renders/spotify/CNowPlaying";
+import CTopTracks from "./renders/spotify/CTopTracks";
+import CRecentlyPlayed from "./renders/spotify/CRecentlyPlayed";
+
+export type SpotifyCommandDescriptor = {
+  command: "now" | "top" | "history";
+  description: string;
+};
+
+type SpotifyCommandDef = SpotifyCommandDescriptor & {
+  render: () => ReactNode;
+};
+
+export const SPOTIFY_COMMAND_DEFS: SpotifyCommandDef[] = [
+  {
+    command: "now",
+    description: "Display the currently playing song",
+    render: () => <CNowPlaying />,
+  },
+  {
+    command: "top",
+    description: "Display my top tracks",
+    render: () => <CTopTracks />,
+  },
+  {
+    command: "history",
+    description: "Display my listening history",
+    render: () => <CRecentlyPlayed />,
+  },
+];
+
+export const SPOTIFY_COMMANDS: SpotifyCommandDescriptor[] =
+  SPOTIFY_COMMAND_DEFS.map(({ command, description }) => ({
+    command,
+    description,
+  }));
+
+export const SPOTIFY_COMMAND_RENDERERS: Record<
+  SpotifyCommandDescriptor["command"],
+  () => ReactNode
+> = Object.fromEntries(
+  SPOTIFY_COMMAND_DEFS.map((c) => [c.command, c.render])
+  // Object.fromEntries cannot preserve the string-literal key union.
+) as Record<SpotifyCommandDescriptor["command"], () => ReactNode>;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -28,64 +28,9 @@ export const SOCIALS: {
   },
 ];
 
-export const COMMANDS = [
-  {
-    command: "welcome",
-    description: "Display a welcome message and introduction",
-  },
-  {
-    command: "help",
-    description: "Display a list of available commands and their descriptions",
-  },
-  {
-    command: "clear",
-    description: "Clear all previous commands and output from the terminal",
-  },
-  {
-    command: "reset",
-    description: "Reset the terminal to the initial state",
-  },
-  {
-    command: "projects",
-    description:
-      "Browse through my portfolio of personal and professional projects",
-  },
-  {
-    command: "skills",
-    description: "View my technical skills, tools and technologies I work with",
-  },
-  {
-    command: "about",
-    description: "Learn more about my background, interests and career goals",
-  },
-  {
-    command: "education",
-    description: "See my academic background and qualifications",
-  },
-  {
-    command: "experiences",
-    description: "Explore my professional work history and accomplishments",
-  },
-  {
-    command: "spotify",
-    description: "Display the help for the spotify commands",
-  },
-];
-
-export const SPOTIFY_COMMANDS = [
-  {
-    command: "now",
-    description: "Display the currently playing song",
-  },
-  {
-    command: "top",
-    description: "Display my top tracks",
-  },
-  {
-    command: "history",
-    description: "Display my listening history",
-  },
-];
+// Commands/Spotify commands were moved to:
+// - components/commands/registry.tsx
+// - components/commands/spotify-registry.tsx
 
 export const PROJECTS = [
   {

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,4 +1,5 @@
 export type Command = {
+  id: string;
   input: string;
   timestamp: Date;
 };


### PR DESCRIPTION
## Terminal reliability
- Generate stable `id` per command (no invalid DOM ids from user input)
- Use `id` for scroll target + React keys
- Normalize commands to `trim().toLowerCase()`

## Command registry
- Single source of truth for command list and renderers (`components/commands/registry.tsx`)
- Same for Spotify subcommands (`components/commands/spotify-registry.tsx`)
- Removes duplicated switch/constants wiring

## Spotify hardening
- Guard missing env vars (return `null` instead of sending bad auth)
- `cache: "no-store"` for realtime responses
- User-facing message when Spotify is not configured

Checks: `pnpm lint`, `pnpm typecheck`, `pnpm build`
