### PR TITLE
P1: terminal UX (custom autocomplete, history, suggestions)

### DIFF
--- a/components/SuggestionList.tsx
+++ b/components/SuggestionList.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import type { Suggestion, SuggestionGroup } from "@/hooks/useSuggestions";
+import { Tag } from "./ui/Tag";
+
+interface SuggestionListProps {
+  suggestions: Suggestion[];
+  activeIndex: number;
+  onSelect: (index: number) => void;
+}
+
+const GROUP_TAG_VARIANT: Record<
+  SuggestionGroup,
+  "teal" | "gold" | "purple" | "default"
+> = {
+  Work: "teal",
+  Profile: "gold",
+  Spotify: "purple",
+  Commands: "default",
+};
+
+function SuggestionList({
+  suggestions,
+  activeIndex,
+  onSelect,
+}: SuggestionListProps) {
+  const itemRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
+
+  useEffect(() => {
+    const el = itemRefs.current.get(activeIndex);
+    el?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [activeIndex]);
+
+  return (
+    <div
+      role="listbox"
+      className="absolute left-0 right-0 bottom-full mb-2 rounded-lg border border-border bg-background/95 backdrop-blur p-1 shadow-lg max-h-44 overflow-auto"
+    >
+      {suggestions.map((s, idx) => (
+        <button
+          key={s.value}
+          ref={(el) => {
+            if (el) {
+              itemRefs.current.set(idx, el);
+            } else {
+              itemRefs.current.delete(idx);
+            }
+          }}
+          type="button"
+          role="option"
+          aria-selected={idx === activeIndex}
+          className={cn(
+            "w-full text-left rounded-md px-2 py-1.5 transition-colors",
+            idx === activeIndex
+              ? "bg-accent text-accent-foreground"
+              : "hover:bg-accent/70",
+          )}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => onSelect(idx)}
+        >
+          <div className="flex items-baseline justify-between gap-3">
+            <span className="font-mono text-sm font-semibold">{s.value}</span>
+            <Tag label={s.group} variant={GROUP_TAG_VARIANT[s.group]} />
+          </div>
+          {s.description && (
+            <div className="text-xs text-muted-foreground line-clamp-1">
+              {s.description}
+            </div>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default SuggestionList;

--- a/components/TerminalInput.tsx
+++ b/components/TerminalInput.tsx
@@ -1,72 +1,75 @@
 "use client";
 
 import { ArrowRight } from "lucide-react";
+import { useRef, useState } from "react";
 import { useCommands } from "./CommandsProvider";
-import {
-  COMMANDS,
-  SPOTIFY_COMMANDS,
-} from "@/components/commands/command-descriptors";
-import { useState } from "react";
+import { useCommandHistory } from "@/hooks/useCommandHistory";
+import { useSuggestions } from "@/hooks/useSuggestions";
+import { useInputHandlers } from "@/hooks/useInputHandlers";
+import SuggestionList from "./SuggestionList";
 
 function TerminalInput() {
   const { addCommand } = useCommands();
   const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (value === "") return;
-    addCommand(value);
-    setValue("");
-    if (window.innerWidth <= 768) {
-      (document.activeElement as HTMLElement)?.blur();
-    }
-  };
+  const { navigateHistory, resetHistory } = useCommandHistory(value, setValue);
 
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      if (value === "") return;
-      addCommand(value);
-      setValue("");
-      if (window.innerWidth <= 768) {
-        e.currentTarget.blur();
-      }
-    }
-  };
+  const {
+    suggestions,
+    isOpen,
+    safeActiveIndex,
+    openPopover,
+    closePopover,
+    moveActiveIndex,
+    applyTabCompletion,
+    applyActiveSuggestion,
+    applySuggestion,
+  } = useSuggestions(value, setValue);
+
+  const { handleSubmit, handleKeyDown, handleChange, handleFocus } =
+    useInputHandlers({
+      value,
+      setValue,
+      addCommand,
+      navigateHistory,
+      resetHistory,
+      isOpen,
+      activeIndex: safeActiveIndex,
+      suggestionsCount: suggestions.length,
+      openPopover,
+      closePopover,
+      moveActiveIndex,
+      applyTabCompletion,
+      applyActiveSuggestion,
+      hasSuggestions: suggestions.length > 0,
+    });
 
   return (
     <div className="relative">
       <form onSubmit={handleSubmit}>
+        {isOpen && (
+          <SuggestionList
+            suggestions={suggestions}
+            activeIndex={safeActiveIndex}
+            onSelect={(idx) => {
+              applySuggestion(idx);
+              inputRef.current?.focus();
+            }}
+          />
+        )}
+
         <input
           type="text"
           value={value}
-          onChange={(e) => setValue(e.target.value.toLowerCase())}
+          onChange={handleChange}
           placeholder="Type 'help' or your command here..."
           className="outline-none bg-transparent border w-full h-10 p-2 pr-10 rounded-md text-sm"
-          onKeyDown={handleKeyPress}
+          onKeyDown={handleKeyDown}
+          onFocus={handleFocus}
           autoComplete="off"
-          list={
-            value.length > 0
-              ? value.startsWith("spotify")
-                ? "spotify-commands-autocomplete"
-                : "commands-autocomplete"
-              : undefined
-          }
+          ref={inputRef}
         />
-        <datalist id="commands-autocomplete">
-          {COMMANDS.map((command) => (
-            <option key={command.command} value={command.command}>
-              {command.description}
-            </option>
-          ))}
-        </datalist>
-        <datalist id="spotify-commands-autocomplete">
-          {SPOTIFY_COMMANDS.map((command) => (
-            <option key={command.command} value={`spotify ${command.command}`}>
-              {command.description}
-            </option>
-          ))}
-        </datalist>
 
         <button
           type="submit"

--- a/components/WelcomeHero.tsx
+++ b/components/WelcomeHero.tsx
@@ -83,7 +83,7 @@ function WelcomeHero({ className }: { className?: string }) {
         </ShortcutRow>
 
         <ShortcutRow label="Extras">
-          <Shortcut label="spotify" command="spotify" />
+          <Shortcut label="spotify" command="spotify" variant="purple" />
           <Shortcut label="help" command="help" />
         </ShortcutRow>
       </ShortcutSection>

--- a/components/commands/command-descriptors.ts
+++ b/components/commands/command-descriptors.ts
@@ -5,29 +5,12 @@ export type CommandDescriptor = {
 
 export const COMMANDS: CommandDescriptor[] = [
   {
-    command: "help",
-    description: "Display a list of available commands and their descriptions",
+    command: "about",
+    description: "Learn more about my background, interests and career goals",
   },
   {
     command: "clear",
     description: "Clear all previous commands and output from the terminal",
-  },
-  {
-    command: "reset",
-    description: "Reset the terminal to the initial state",
-  },
-  {
-    command: "projects",
-    description:
-      "Browse through my portfolio of personal and professional projects",
-  },
-  {
-    command: "skills",
-    description: "View my technical skills, tools and technologies I work with",
-  },
-  {
-    command: "about",
-    description: "Learn more about my background, interests and career goals",
   },
   {
     command: "education",
@@ -36,6 +19,27 @@ export const COMMANDS: CommandDescriptor[] = [
   {
     command: "experiences",
     description: "Explore my professional work history and accomplishments",
+  },
+  {
+    command: "help",
+    description: "Display a list of available commands and their descriptions",
+  },
+  {
+    command: "projects",
+    description:
+      "Browse through my portfolio of personal and professional projects",
+  },
+  {
+    command: "reset",
+    description: "Reset the terminal to the initial state",
+  },
+  {
+    command: "skills",
+    description: "View my technical skills, tools and technologies I work with",
+  },
+  {
+    command: "spotify",
+    description: "Display the help for the spotify commands",
   },
 ];
 
@@ -46,15 +50,15 @@ export type SpotifyCommandDescriptor = {
 
 export const SPOTIFY_COMMANDS: SpotifyCommandDescriptor[] = [
   {
+    command: "history",
+    description: "Display my listening history",
+  },
+  {
     command: "now",
     description: "Display the currently playing song",
   },
   {
     command: "top",
     description: "Display my top tracks",
-  },
-  {
-    command: "history",
-    description: "Display my listening history",
   },
 ];

--- a/components/commands/renders/CAbout.tsx
+++ b/components/commands/renders/CAbout.tsx
@@ -1,5 +1,6 @@
 import { AnimatedSpan } from "@/components/AnimatedComponents";
 import { HOBBIES, LANGUAGES } from "@/lib/constants";
+import Link from "next/link";
 
 function CAbout() {
   return (
@@ -11,7 +12,9 @@ function CAbout() {
         value={`${Math.floor((new Date().getTime() - new Date("2002-12-24").getTime()) / (1000 * 60 * 60 * 24 * 365.25))} years`}
       />
       <Info title="Location" value="Châlons-en-Champagne, France" />
-      <Info title="Email" value="alex@kabila.app" />
+      <p className="text-muted-foreground">
+        Email: <Link href="mailto:alexandre.gossard.pro@gmail.com" className="font-semibold text-chart-1 hover:text-chart-1/80 transition-colors duration-200">alexandre.gossard.pro@gmail.com</Link>
+      </p>
       <Info
         title="Languages"
         value={LANGUAGES.map((lang) => `${lang.lang} (${lang.level})`).join(

--- a/components/commands/renders/CEducation.tsx
+++ b/components/commands/renders/CEducation.tsx
@@ -13,7 +13,7 @@ function CEducation() {
             idx === EDUCATION.length - 1 && "pb-1",
           )}
         >
-          <div className="absolute -left-[5px] size-2 top-1 rounded-full bg-chart-2 z-[1]" />
+          <div className="absolute -left-[5px] size-2 top-1 rounded-full bg-chart-1 z-[1]" />
           <p className="text-muted-foreground">{education.period}</p>
           <p className="text-sm font-semibold">{education.name}</p>
           <p className="text-muted-foreground">{education.location}</p>

--- a/components/commands/renders/CExperiences.tsx
+++ b/components/commands/renders/CExperiences.tsx
@@ -13,9 +13,9 @@ function CExperiences() {
             idx === EXPERIENCES.length - 1 && "pb-1",
           )}
         >
-          <div className="absolute -left-[5px] size-2 top-1 rounded-full bg-chart-2 z-[1]" />
+          <div className="absolute -left-[5px] size-2 top-1 rounded-full bg-chart-1 z-[1]" />
           {experience.period.toLowerCase().includes("since") && (
-            <div className="absolute -left-[5px] size-2 top-1 animate-ping rounded-full bg-chart-2 opacity-75" />
+            <div className="absolute -left-[5px] size-2 top-1 animate-ping rounded-full bg-chart-1 opacity-75" />
           )}
           <p className="text-muted-foreground">{experience.period}</p>
           <p className="text-sm font-semibold">{experience.name}</p>

--- a/components/commands/renders/CNotFound.tsx
+++ b/components/commands/renders/CNotFound.tsx
@@ -1,11 +1,79 @@
+"use client";
+
 import { AnimatedSpan } from "@/components/AnimatedComponents";
+import { useCommands } from "@/components/CommandsProvider";
+import {
+  COMMANDS,
+  SPOTIFY_COMMANDS,
+} from "@/components/commands/command-descriptors";
+import { useMemo } from "react";
+
+function levenshtein(a: string, b: string) {
+  const dp = Array.from({ length: a.length + 1 }, () =>
+    new Array<number>(b.length + 1).fill(0),
+  );
+  for (let i = 0; i <= a.length; i++) dp[i][0] = i;
+  for (let j = 0; j <= b.length; j++) dp[0][j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + cost,
+      );
+    }
+  }
+  return dp[a.length][b.length];
+}
 
 function CNotFound({ input }: { input: string }) {
+  const { addCommand } = useCommands();
+
+  const suggestions = useMemo(() => {
+    const q = input.trim().toLowerCase();
+    if (!q) return [] as string[];
+
+    const base = COMMANDS.map((c) => c.command);
+    const spotify = ["spotify", ...SPOTIFY_COMMANDS.map((c) => `spotify ${c.command}`)];
+
+    const candidates = Array.from(
+      new Set(q.startsWith("spotify") ? spotify : [...base, ...spotify]),
+    );
+
+    const startsWith = candidates.filter((c) => c.startsWith(q));
+    if (startsWith.length > 0) return startsWith.slice(0, 3);
+
+    const maxDistance = Math.max(2, Math.ceil(q.length / 3));
+    return candidates
+      .map((c) => ({ c, d: levenshtein(q, c) }))
+      .filter((x) => x.d <= maxDistance && x.c !== q)
+      .sort((a, b) => a.d - b.d || a.c.length - b.c.length)
+      .slice(0, 3)
+      .map((x) => x.c);
+  }, [input]);
+
   return (
     <AnimatedSpan>
-      <p className="text-destructive">
-        Command &apos;{input}&apos; was not found.
-      </p>
+      <p className="text-destructive">Command &apos;{input}&apos; was not found.</p>
+      {suggestions.length > 0 && (
+        <p className="text-muted-foreground">
+          Did you mean{" "}
+          {suggestions.map((s, idx) => (
+            <span key={s}>
+              <button
+                type="button"
+                className="text-chart-2 hover:text-chart-2/80 transition-colors duration-200 font-semibold"
+                onClick={() => addCommand(s)}
+              >
+                {s}
+              </button>
+              {idx < suggestions.length - 1 ? ", " : ""}
+            </span>
+          ))}
+          ?
+        </p>
+      )}
     </AnimatedSpan>
   );
 }

--- a/components/commands/renders/CProjects.tsx
+++ b/components/commands/renders/CProjects.tsx
@@ -33,7 +33,7 @@ function CProjects() {
                   .map((tag) => (
                     <p
                       key={tag}
-                      className="text-xs rounded-xs py-1 px-2 bg-chart-2/10 text-chart-2"
+                      className="text-xs rounded-xs py-1 px-2 bg-chart-1/10 text-chart-1"
                     >
                       {tag}
                     </p>

--- a/components/commands/renders/spotify/CNowPlaying.tsx
+++ b/components/commands/renders/spotify/CNowPlaying.tsx
@@ -25,7 +25,7 @@ function CNowPlaying() {
                 className="rounded-sm"
               />
               <div>
-                <p className="text-sm font-semibold group-hover:text-chart-2 transition-colors duration-200">
+                <p className="text-sm font-semibold group-hover:text-chart-1 transition-colors duration-200">
                   {data.item.name}
                 </p>
                 <p className="text-muted-foreground">

--- a/components/commands/renders/spotify/CRecentlyPlayed.tsx
+++ b/components/commands/renders/spotify/CRecentlyPlayed.tsx
@@ -26,7 +26,7 @@ function CRecentlyPlayed() {
               />
               <div className="flex flex-col sm:flex-row items-start sm:items-center flex-1 gap-1">
                 <div className="flex-1">
-                  <p className="text-sm leading-4 line-clamp-1 font-semibold group-hover:text-chart-2 transition-colors duration-200">
+                  <p className="text-sm leading-4 line-clamp-1 font-semibold group-hover:text-chart-1 transition-colors duration-200">
                     {item.track.name}
                   </p>
                   <p className="text-muted-foreground line-clamp-1">

--- a/components/commands/renders/spotify/CTopTracks.tsx
+++ b/components/commands/renders/spotify/CTopTracks.tsx
@@ -35,7 +35,7 @@ function CTopTracks() {
                         className="rounded-sm"
                       />
                       <div>
-                        <p className="text-sm leading-4 line-clamp-2 font-semibold group-hover:text-chart-2 transition-colors duration-200">
+                        <p className="text-sm leading-4 line-clamp-2 font-semibold group-hover:text-chart-1 transition-colors duration-200">
                           {item.name}
                         </p>
                         <p className="text-muted-foreground">
@@ -49,7 +49,7 @@ function CTopTracks() {
                       <Link
                         href={item.album.external_urls.spotify}
                         target="_blank"
-                        className="hover:text-chart-2 leading-4 font-semibold line-clamp-2 text-sm transition-colors duration-200"
+                        className="hover:text-chart-1 leading-4 font-semibold line-clamp-2 text-sm transition-colors duration-200"
                       >
                         {item.album.name}
                       </Link>

--- a/components/ui/Shortcut.tsx
+++ b/components/ui/Shortcut.tsx
@@ -15,6 +15,8 @@ const shortcutVariants = cva(
           "bg-chart-1/10 text-chart-1 ring-chart-1/20 hover:bg-chart-1/20",
         secondary:
           "bg-chart-2/10 text-chart-2 ring-chart-2/20 hover:bg-chart-2/20",
+        purple:
+          "bg-chart-3/10 text-chart-3 ring-chart-3/20 hover:bg-chart-3/20",
       },
     },
     defaultVariants: {

--- a/hooks/useCommandHistory.ts
+++ b/hooks/useCommandHistory.ts
@@ -1,0 +1,51 @@
+import { useMemo, useRef, useState, useCallback } from "react";
+import { useCommands } from "@/components/CommandsProvider";
+
+/**
+ * Manages browsing through previously executed commands with ↑/↓ or Ctrl-P/N.
+ *
+ * - Keeps a draft of the current input so it can be restored when the user
+ *   leaves history mode (offset goes back to 0).
+ * - Exposes `navigateHistory(delta)` instead of raw offset manipulation.
+ */
+export function useCommandHistory(
+  value: string,
+  setValue: (v: string) => void,
+) {
+  const { commands } = useCommands();
+  const [historyOffset, setHistoryOffset] = useState(0);
+  const draftRef = useRef("");
+
+  const history = useMemo(() => commands.map((c) => c.input), [commands]);
+
+  const navigateHistory = useCallback(
+    (delta: number) => {
+      if (history.length === 0) return;
+
+      const nextOffset = historyOffset + delta;
+      const clamped = Math.max(0, Math.min(nextOffset, history.length));
+
+      // Avoid clearing the input when the user isn't browsing history.
+      if (historyOffset === 0 && clamped === 0) return;
+
+      // Save the current input as draft when entering history mode.
+      if (historyOffset === 0 && clamped > 0) draftRef.current = value;
+      setHistoryOffset(clamped);
+
+      if (clamped === 0) {
+        setValue(draftRef.current);
+        return;
+      }
+
+      setValue(history[history.length - clamped]);
+    },
+    [history, historyOffset, value, setValue],
+  );
+
+  const resetHistory = useCallback(() => {
+    setHistoryOffset(0);
+    draftRef.current = "";
+  }, []);
+
+  return { historyOffset, navigateHistory, resetHistory } as const;
+}

--- a/hooks/useInputHandlers.ts
+++ b/hooks/useInputHandlers.ts
@@ -1,0 +1,145 @@
+import { useCallback } from "react";
+
+interface UseInputHandlersOptions {
+  value: string;
+  setValue: (v: string) => void;
+  addCommand: (input: string) => void;
+  // History
+  navigateHistory: (delta: number) => void;
+  resetHistory: () => void;
+  // Suggestions
+  isOpen: boolean;
+  activeIndex: number;
+  suggestionsCount: number;
+  openPopover: () => void;
+  closePopover: () => void;
+  moveActiveIndex: (delta: number) => void;
+  applyTabCompletion: () => void;
+  applyActiveSuggestion: () => boolean;
+  hasSuggestions: boolean;
+}
+
+/**
+ * Orchestrates all input event handlers (keydown, submit, change, focus)
+ * by composing actions from the history and suggestions hooks.
+ */
+export function useInputHandlers({
+  value,
+  setValue,
+  addCommand,
+  navigateHistory,
+  resetHistory,
+  isOpen,
+  activeIndex,
+  suggestionsCount,
+  openPopover,
+  closePopover,
+  moveActiveIndex,
+  applyTabCompletion,
+  applyActiveSuggestion,
+  hasSuggestions,
+}: UseInputHandlersOptions) {
+  const submit = useCallback(() => {
+    if (value === "") return;
+    addCommand(value);
+    setValue("");
+    resetHistory();
+    closePopover();
+    if (window.innerWidth <= 768) {
+      (document.activeElement as HTMLElement)?.blur();
+    }
+  }, [value, addCommand, setValue, resetHistory, closePopover]);
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      submit();
+    },
+    [submit],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      // Ctrl/Cmd + P/N → history navigation
+      if ((e.ctrlKey || e.metaKey) && (e.key === "p" || e.key === "n")) {
+        e.preventDefault();
+        navigateHistory(e.key === "p" ? 1 : -1);
+        return;
+      }
+
+      // Tab → autocomplete
+      if (e.key === "Tab") {
+        e.preventDefault();
+        applyTabCompletion();
+        return;
+      }
+
+      // Arrow Up
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        if (isOpen && activeIndex > 0) {
+          moveActiveIndex(-1);
+        } else {
+          if (isOpen) closePopover();
+          navigateHistory(1);
+        }
+        return;
+      }
+
+      // Arrow Down
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        if (isOpen && activeIndex < suggestionsCount - 1) {
+          moveActiveIndex(1);
+        } else {
+          if (isOpen) closePopover();
+          navigateHistory(-1);
+        }
+        return;
+      }
+
+      // Escape → close popover
+      if (e.key === "Escape") {
+        if (!isOpen) return;
+        e.preventDefault();
+        closePopover();
+        return;
+      }
+
+      // Enter → apply suggestion or submit
+      if (e.key === "Enter") {
+        e.preventDefault();
+        if (isOpen && applyActiveSuggestion()) return;
+        submit();
+      }
+    },
+    [
+      isOpen,
+      activeIndex,
+      suggestionsCount,
+      navigateHistory,
+      applyTabCompletion,
+      moveActiveIndex,
+      closePopover,
+      applyActiveSuggestion,
+      submit,
+    ],
+  );
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setValue(e.target.value.toLowerCase());
+      resetHistory();
+      openPopover();
+    },
+    [setValue, resetHistory, openPopover],
+  );
+
+  const handleFocus = useCallback(() => {
+    if (value.trim().length > 0 && hasSuggestions) {
+      openPopover();
+    }
+  }, [value, hasSuggestions, openPopover]);
+
+  return { handleSubmit, handleKeyDown, handleChange, handleFocus } as const;
+}

--- a/hooks/useSuggestions.ts
+++ b/hooks/useSuggestions.ts
@@ -1,0 +1,186 @@
+import { useMemo, useState, useCallback } from "react";
+import {
+  COMMANDS,
+  SPOTIFY_COMMANDS,
+} from "@/components/commands/command-descriptors";
+
+export type SuggestionGroup = "Work" | "Profile" | "Spotify" | "Commands";
+
+export type Suggestion = {
+  value: string;
+  description?: string;
+  group: SuggestionGroup;
+};
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+
+function longestCommonPrefix(items: string[]): string {
+  if (items.length === 0) return "";
+  let prefix = items[0];
+  for (const item of items) {
+    while (prefix && !item.startsWith(prefix)) {
+      prefix = prefix.slice(0, -1);
+    }
+    if (!prefix) return "";
+  }
+  return prefix;
+}
+
+const COMMAND_GROUP_MAP: Record<string, SuggestionGroup> = {
+  projects: "Work",
+  experiences: "Work",
+  skills: "Profile",
+  about: "Profile",
+  education: "Profile",
+  spotify: "Spotify",
+};
+
+function buildSuggestionPool(): Suggestion[] {
+  const base: Suggestion[] = COMMANDS.map((c) => ({
+    value: c.command,
+    description: c.description,
+    group: COMMAND_GROUP_MAP[c.command] ?? "Commands",
+  }));
+
+  const spotify: Suggestion[] = SPOTIFY_COMMANDS.map((c) => ({
+    value: `spotify ${c.command}`,
+    description: c.description,
+    group: "Spotify" as const,
+  }));
+
+  // De-dupe by value (COMMANDS already includes "spotify").
+  const map = new Map<string, Suggestion>();
+  for (const s of [...base, ...spotify]) map.set(s.value, s);
+
+  return Array.from(map.values()).sort((a, b) =>
+    a.value.localeCompare(b.value),
+  );
+}
+
+// ─── Hook ──────────────────────────────────────────────────────────────
+
+/**
+ * Manages the autocomplete suggestion popover:
+ * filtering, active-index tracking, tab-completion, and selection.
+ */
+export function useSuggestions(value: string, setValue: (v: string) => void) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const allSuggestions = useMemo(() => buildSuggestionPool(), []);
+
+  const suggestions = useMemo(() => {
+    const q = value.trim().toLowerCase();
+    if (!q) return [] as Suggestion[];
+
+    if (q === "spotify") {
+      return allSuggestions.filter((s) => s.value.startsWith(q)).slice(0, 8);
+    }
+
+    if (q.startsWith("spotify ")) {
+      return allSuggestions
+        .filter((s) => s.value.startsWith("spotify "))
+        .filter((s) => s.value.startsWith(q))
+        .slice(0, 8);
+    }
+
+    return allSuggestions.filter((s) => s.value.startsWith(q)).slice(0, 8);
+  }, [allSuggestions, value]);
+
+  const isOpen = value.trim().length > 0 && suggestions.length > 0 && open;
+  const safeActiveIndex = Math.max(
+    0,
+    Math.min(activeIndex, Math.max(0, suggestions.length - 1)),
+  );
+
+  // ── Actions ────────────────────────────────────────────────────────
+
+  const openPopover = useCallback(() => {
+    setOpen(true);
+    setActiveIndex(0);
+  }, []);
+
+  const closePopover = useCallback(() => {
+    setOpen(false);
+    setActiveIndex(0);
+  }, []);
+
+  const moveActiveIndex = useCallback(
+    (delta: number) => {
+      setActiveIndex((i) => {
+        const next = i + delta;
+        return Math.max(0, Math.min(suggestions.length - 1, next));
+      });
+    },
+    [suggestions.length],
+  );
+
+  const applyTabCompletion = useCallback(() => {
+    const q = value.trim().toLowerCase();
+    if (!q) return;
+
+    // Special case: bare "spotify" → append a space to drill into subcommands.
+    if (q === "spotify") {
+      setValue("spotify ");
+      openPopover();
+      return;
+    }
+
+    const matches = suggestions.map((s) => s.value);
+    if (matches.length === 0) return;
+
+    if (matches.length === 1) {
+      setValue(matches[0]);
+      closePopover();
+      return;
+    }
+
+    const lcp = longestCommonPrefix(matches);
+    if (lcp && lcp !== q) {
+      setValue(lcp);
+      openPopover();
+    }
+  }, [value, suggestions, setValue, openPopover, closePopover]);
+
+  /** Apply the currently highlighted suggestion. Returns `true` if the value
+   *  was actually changed (i.e. it was a partial completion). Returns `false`
+   *  when there's nothing to apply or the input already matches exactly, so
+   *  the caller can fall through to submit. */
+  const applyActiveSuggestion = useCallback((): boolean => {
+    const s = suggestions[safeActiveIndex];
+    if (!s) return false;
+
+    // Value already matches — just close the popover and let Enter submit.
+    if (value.trim().toLowerCase() === s.value) {
+      closePopover();
+      return false;
+    }
+
+    setValue(s.value);
+    closePopover();
+    return true;
+  }, [suggestions, safeActiveIndex, value, setValue, closePopover]);
+
+  /** Pick a specific suggestion by index (e.g. on click). */
+  const applySuggestion = useCallback(
+    (index: number) => {
+      const s = suggestions[index];
+      if (!s) return;
+      setValue(s.value);
+      closePopover();
+    },
+    [suggestions, setValue, closePopover],
+  );
+
+  return {
+    suggestions,
+    isOpen,
+    safeActiveIndex,
+    openPopover,
+    closePopover,
+    moveActiveIndex,
+    applyTabCompletion,
+    applyActiveSuggestion,
+    applySuggestion,
+  } as const;
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --max-warnings=0",
-    "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
+    "typecheck": "tsc --noEmit",
     "prettier:fix": "prettier --write \"**/*.{ts,tsx,mdx}\" --cache"
   },
   "author": {

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true,
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
-  }
-}
-


### PR DESCRIPTION
## What
Improves the terminal UX (P1 next) by replacing the native `datalist` with a custom autocomplete popover, adding robust keyboard history navigation, and improving the unknown-command experience.

## Terminal input
- Replace native `datalist` with a custom suggestions popover rendered above the input.
- Keyboard support:
  - `Tab`: completes (single match) or extends to the longest common prefix.
  - `↑/↓`: navigates suggestions when open; otherwise navigates command history.
  - `Enter`: applies the active suggestion when it’s a partial completion; otherwise submits.
  - `Esc`: closes the suggestions popover.
  - `Ctrl/Cmd + P` / `Ctrl/Cmd + N`: history navigation (works regardless of suggestions).
- Suggestions include command descriptions and are grouped (Work/Profile/Spotify/Commands).
- No localStorage persistence (in-memory only).

## Commands
- `spotify` is now part of the base commands list so it’s discoverable via autocomplete/help.
- `Command not found` now offers up to 3 clickable suggestions based on prefix match or edit-distance.

## Visual polish
- Minor theme/color alignment for timeline dots and project tags.
- Welcome shortcuts: highlight `spotify` with a purple shortcut variant.

## Dev experience
- Fix `pnpm typecheck` to use `tsc --noEmit` (previous NodeNext config was failing on relative imports).

## Files
- Autocomplete + input orchestration:
  - `components/TerminalInput.tsx`
  - `components/SuggestionList.tsx`
  - `hooks/useCommandHistory.ts`
  - `hooks/useSuggestions.ts`
  - `hooks/useInputHandlers.ts`
- Command descriptors + not-found suggestions:
  - `components/commands/command-descriptors.ts`
  - `components/commands/renders/CNotFound.tsx`
- Small UI tweaks:
  - `components/WelcomeHero.tsx`
  - `components/ui/Shortcut.tsx`
  - `components/commands/renders/CAbout.tsx`
  - `components/commands/renders/CProjects.tsx`
  - `components/commands/renders/CEducation.tsx`
  - `components/commands/renders/CExperiences.tsx`
  - `components/commands/renders/spotify/*`

## Checks
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
