### PR TITLE
update(stats): track unique visitors by IP instead of page views

### DIFF
--- a/components/commands/command-descriptors.ts
+++ b/components/commands/command-descriptors.ts
@@ -104,7 +104,8 @@ export const COMMANDS: CommandDescriptor[] = [
   },
   {
     command: "stats",
-    description: "Display live metrics from WakaTime, GitHub, Spotify & more",
+    description:
+      "Display coding activity, GitHub metrics & unique visitor count",
     group: "Profile",
   },
   {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,17 +1,24 @@
 import { createClient } from "@supabase/supabase-js";
 import { after, type NextRequest, NextResponse } from "next/server";
 
-export function proxy(_request: NextRequest) {
+export function proxy(request: NextRequest) {
   if (process.env.NODE_ENV !== "production") return NextResponse.next();
 
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (url && key) {
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+      request.headers.get("x-real-ip") ??
+      null;
+
     after(async () => {
+      if (!ip) return;
+
       const supabase = createClient(url, key);
       try {
-        await supabase.rpc("increment_page_views");
+        await supabase.rpc("track_visitor", { visitor_ip: ip });
       } catch {}
     });
   }


### PR DESCRIPTION
## Summary
- Replace `increment_page_views` RPC with `track_visitor` RPC that deduplicates by visitor IP address
- Extract client IP from `x-forwarded-for` / `x-real-ip` headers in the proxy middleware
- Update stats command description to reflect new unique visitor metric

## Test plan
- [x] Verify visitor tracking fires correctly in production with valid IP extraction
- [x] Confirm `track_visitor` Supabase RPC handles duplicate IPs gracefully
- [x] Check stats command displays updated description in terminal


Made with [Cursor](https://cursor.com)