### PR TITLE
feat: v1.2.0 — new commands, terminal redesign, analytics & CV generation

### DIFF
--- a/components/commands/command-descriptors.ts
+++ b/components/commands/command-descriptors.ts
@@ -104,7 +104,8 @@ export const COMMANDS: CommandDescriptor[] = [
   },
   {
     command: "stats",
-    description: "Display live metrics from WakaTime, GitHub, Spotify & more",
+    description:
+      "Display coding activity, GitHub metrics & unique visitor count",
     group: "Profile",
   },
   {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,17 +1,24 @@
 import { createClient } from "@supabase/supabase-js";
 import { after, type NextRequest, NextResponse } from "next/server";
 
-export function proxy(_request: NextRequest) {
+export function proxy(request: NextRequest) {
   if (process.env.NODE_ENV !== "production") return NextResponse.next();
 
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (url && key) {
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+      request.headers.get("x-real-ip") ??
+      null;
+
     after(async () => {
+      if (!ip) return;
+
       const supabase = createClient(url, key);
       try {
-        await supabase.rpc("increment_page_views");
+        await supabase.rpc("track_visitor", { visitor_ip: ip });
       } catch {}
     });
   }


### PR DESCRIPTION
## Summary

This PR merges all `develop` changes into `main` for the next release. Key highlights:

- **New commands & refactored command system** — added `contact`, `cv`, `echo`, `repo`, `stats`, `theme` commands with subcommand help, and restructured the command registry
- **Terminal redesign** — macOS-style chrome with traffic lights, improved input handling, and a new `TerminalProvider`
- **PDF resume generation** — `/api/cv` endpoint powered by `react-pdf` with styled CV sections and data
- **Analytics & unique visitor tracking** — page view tracking via Supabase, unique visitors tracked by IP (`/api/views`)
- **Service layer extraction** — server actions delegated to dedicated service modules (`github`, `spotify`, `wakatime`, `analytics`, `stats`)
- **UX improvements** — global keyboard shortcuts, enhanced suggestion list, updated welcome hero and footer
- **Chores** — new dependencies (`react-pdf`, `@supabase/supabase-js`), relaxed Biome rules, updated env template

### Commits (13)

| Type | Description |
|------|-------------|
| `update(stats)` | Track unique visitors by IP instead of page views |
| `fix(lint)` | Sort imports to satisfy Biome organizeImports rule |
| `feat(ux)` | Add global shortcuts and improve input/suggestion UX |
| `refactor(terminal)` | Redesign terminal with macOS-style chrome |
| `feat(commands)` | Add new commands and refactor command system |
| `feat(analytics)` | Add page view tracking with Supabase |
| `feat(cv)` | Add PDF resume generation with react-pdf |
| `refactor(content)` | Update site metadata, skill labels, and languages |
| `refactor(actions)` | Delegate server actions to service modules |
| `feat(lib)` | Add service layer with types and Supabase client |
| `chore(config)` | Update environment template and relax biome rules |
| `chore(deps)` | Add react-pdf and supabase dependencies |
| `chore(main)` | Release 1.1.1 |

**61 files changed** — +3,189 / −561

## Test plan

- [x] Verify all new commands work (`contact`, `cv`, `echo`, `repo`, `stats`, `theme`)
- [x] Test PDF generation at `/api/cv`
- [x] Confirm analytics tracking records unique visitors
- [x] Check terminal UI (traffic lights, input, suggestions)
- [x] Validate global keyboard shortcuts
- [x] Ensure Spotify integration still works after service refactor
- [x] Run `pnpm lint` and `pnpm build` with no errors


Made with [Cursor](https://cursor.com)