### PR TITLE
chore: add pre-commit hook to run Biome on staged files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+biome check --staged --write --no-errors-on-unmatched --colors=off

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "biome format --write .",
     "format:check": "biome ci .",
     "typecheck": "tsc --noEmit",
-    "audit": "pnpm audit --prod --audit-level=high"
+    "audit": "pnpm audit --prod --audit-level=high",
+    "prepare": "husky"
   },
   "author": {
     "name": "Alexandre Gossard",
@@ -48,6 +49,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "husky": "^9.1.7",
     "tailwindcss": "^4",
     "typescript": "^5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.0.4(@types/react@19.0.10)
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       tailwindcss:
         specifier: ^4
         version: 4.0.14
@@ -664,6 +667,11 @@ packages:
 
   hsl-to-rgb-for-reals@1.1.1:
     resolution: {integrity: sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   hyphen@1.14.1:
     resolution: {integrity: sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==}
@@ -1485,6 +1493,8 @@ snapshots:
       hsl-to-rgb-for-reals: 1.1.1
 
   hsl-to-rgb-for-reals@1.1.1: {}
+
+  husky@9.1.7: {}
 
   hyphen@1.14.1: {}
 


### PR DESCRIPTION
## Summary

- Add **husky** pre-commit hook that runs `biome check --staged --write` to automatically lint, format, and organize imports on every commit
- Only staged files are processed, keeping commits fast
- The `prepare` script ensures husky is set up automatically on `pnpm install` for all contributors

## Test plan

- [x] Verified the hook runs successfully on commit (see commit output: `Checked 1 file in 6ms. No fixes applied.`)
- [x] Confirm `pnpm install` sets up husky correctly on a fresh clone

Made with [Cursor](https://cursor.com)