### PR TITLE
refactor: move scroll logic to CommandItem

### DIFF
--- a/components/MainScreen.tsx
+++ b/components/MainScreen.tsx
@@ -1,20 +1,10 @@
 "use client";
 
-import dynamic from "next/dynamic";
+import CommandItem from "./commands/CommandItem";
 import { useCommands } from "./providers/CommandsProvider";
 import { TerminalProvider } from "./providers/TerminalProvider";
 import { Terminal } from "./Terminal";
 import WelcomeHero from "./WelcomeHero";
-
-const CommandItem = dynamic(() => import("./commands/CommandItem"), {
-  loading: () => (
-    <div className="flex items-center gap-1.5">
-      <div className="h-1 w-1 animate-pulse rounded-full bg-primary/60" />
-      <div className="h-1 w-1 animate-pulse rounded-full bg-primary/40 [animation-delay:150ms]" />
-      <div className="h-1 w-1 animate-pulse rounded-full bg-primary/20 [animation-delay:300ms]" />
-    </div>
-  ),
-});
 
 function MainScreen() {
   const { showWelcome, commands } = useCommands();

--- a/components/commands/CommandItem.tsx
+++ b/components/commands/CommandItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { Command } from "@/types";
 import CommandBash from "./CommandBash";
 import { COMMAND_RENDERERS } from "./registries/registry";
@@ -17,17 +17,25 @@ function CommandWrapper({
   timestamp,
 }: { children: React.ReactNode } & Command) {
   const [show, setShow] = useState(false);
+  const commandRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    const timeout = setTimeout(() => {
-      setShow(true);
-    }, 500);
-
+    const timeout = setTimeout(() => setShow(true), 500);
     return () => clearTimeout(timeout);
   }, []);
 
+  useLayoutEffect(() => {
+    if (!show) return;
+    commandRef.current?.scrollIntoView({
+      behavior: "auto",
+      block: "start",
+      inline: "nearest",
+    });
+  }, [show]);
+
   return (
     <div
+      ref={commandRef}
       id={`cmd-${id}`}
       className="flex w-full flex-col gap-2 pt-3 pb-4 first:pt-0"
     >

--- a/components/providers/CommandsProvider.tsx
+++ b/components/providers/CommandsProvider.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useRef,
-  useState,
-} from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 import type { Command } from "@/types";
 
 interface CommandsContextType {
@@ -32,7 +26,6 @@ export function useCommands() {
 export function CommandsProvider({ children }: { children: React.ReactNode }) {
   const [commands, setCommands] = useState<Command[]>([]);
   const [showWelcome, setShowWelcome] = useState(true);
-  const pendingScrollId = useRef<number | null>(null);
 
   const addCommand = (input: string) => {
     if (showWelcome) setShowWelcome(false);
@@ -54,15 +47,6 @@ export function CommandsProvider({ children }: { children: React.ReactNode }) {
         timestamp,
       },
     ]);
-
-    if (pendingScrollId.current) window.clearTimeout(pendingScrollId.current);
-    pendingScrollId.current = window.setTimeout(() => {
-      const command = document.getElementById(`cmd-${id}`);
-
-      if (command) {
-        command.scrollIntoView({ behavior: "smooth", inline: "start" });
-      }
-    }, 500);
   };
 
   const clearCommands = useCallback(() => {


### PR DESCRIPTION
Moves command scroll-into-view logic from CommandsProvider to CommandItem component. Removes dynamic import for CommandItem in MainScreen.

Made with [Cursor](https://cursor.com)