### PR TITLE
refactor: move scroll logic to CommandItem

### DIFF
--- a/.github/RELEASE_FIX_CHECKLIST.md
+++ b/.github/RELEASE_FIX_CHECKLIST.md
@@ -1,0 +1,13 @@
+# Release-Please Stuck State Fix
+
+If you see `There are untagged, merged release PRs outstanding - aborting`:
+
+1. **Remove autorelease labels** from PR #28 (and any other release PRs):
+   - Go to https://github.com/HakkaOfDev/hakkaofdev.fr/pull/28
+   - Remove `autorelease:pending` and `autorelease:tagged` if present
+
+2. **Manually tag the release** (if PR #28's merge never got a tag):
+   - Find the merge commit SHA of PR #28
+   - Run: `git tag v1.1.2 <merge-commit-sha>`
+   - Push: `git push origin v1.1.2`
+   - Or create the GitHub Release manually for that commit

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -2,11 +2,13 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
+  "group-pull-request-title-pattern": "chore${scope}: release ${component} ${version}",
   "include-component-in-tag": false,
   "separate-pull-requests": false,
   "packages": {
     ".": {
       "release-type": "node",
+      "pull-request-title-pattern": "chore${scope}: release ${component} ${version}",
       "changelog-path": "CHANGELOG.md",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },

--- a/components/MainScreen.tsx
+++ b/components/MainScreen.tsx
@@ -1,20 +1,10 @@
 "use client";
 
-import dynamic from "next/dynamic";
+import CommandItem from "./commands/CommandItem";
 import { useCommands } from "./providers/CommandsProvider";
 import { TerminalProvider } from "./providers/TerminalProvider";
 import { Terminal } from "./Terminal";
 import WelcomeHero from "./WelcomeHero";
-
-const CommandItem = dynamic(() => import("./commands/CommandItem"), {
-  loading: () => (
-    <div className="flex items-center gap-1.5">
-      <div className="h-1 w-1 animate-pulse rounded-full bg-primary/60" />
-      <div className="h-1 w-1 animate-pulse rounded-full bg-primary/40 [animation-delay:150ms]" />
-      <div className="h-1 w-1 animate-pulse rounded-full bg-primary/20 [animation-delay:300ms]" />
-    </div>
-  ),
-});
 
 function MainScreen() {
   const { showWelcome, commands } = useCommands();

--- a/components/commands/CommandItem.tsx
+++ b/components/commands/CommandItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { Command } from "@/types";
 import CommandBash from "./CommandBash";
 import { COMMAND_RENDERERS } from "./registries/registry";
@@ -17,17 +17,25 @@ function CommandWrapper({
   timestamp,
 }: { children: React.ReactNode } & Command) {
   const [show, setShow] = useState(false);
+  const commandRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    const timeout = setTimeout(() => {
-      setShow(true);
-    }, 500);
-
+    const timeout = setTimeout(() => setShow(true), 500);
     return () => clearTimeout(timeout);
   }, []);
 
+  useLayoutEffect(() => {
+    if (!show) return;
+    commandRef.current?.scrollIntoView({
+      behavior: "auto",
+      block: "start",
+      inline: "nearest",
+    });
+  }, [show]);
+
   return (
     <div
+      ref={commandRef}
       id={`cmd-${id}`}
       className="flex w-full flex-col gap-2 pt-3 pb-4 first:pt-0"
     >

--- a/components/providers/CommandsProvider.tsx
+++ b/components/providers/CommandsProvider.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useRef,
-  useState,
-} from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 import type { Command } from "@/types";
 
 interface CommandsContextType {
@@ -32,7 +26,6 @@ export function useCommands() {
 export function CommandsProvider({ children }: { children: React.ReactNode }) {
   const [commands, setCommands] = useState<Command[]>([]);
   const [showWelcome, setShowWelcome] = useState(true);
-  const pendingScrollId = useRef<number | null>(null);
 
   const addCommand = (input: string) => {
     if (showWelcome) setShowWelcome(false);
@@ -54,15 +47,6 @@ export function CommandsProvider({ children }: { children: React.ReactNode }) {
         timestamp,
       },
     ]);
-
-    if (pendingScrollId.current) window.clearTimeout(pendingScrollId.current);
-    pendingScrollId.current = window.setTimeout(() => {
-      const command = document.getElementById(`cmd-${id}`);
-
-      if (command) {
-        command.scrollIntoView({ behavior: "smooth", inline: "start" });
-      }
-    }, 500);
   };
 
   const clearCommands = useCallback(() => {


### PR DESCRIPTION
## Summary

Moves scroll logic to CommandItem for better encapsulation. Also fixes release-please PR title pattern so future Release PRs use `chore${scope}: release ${component} ${version}` format.

## Changes

- 3514a90 ci: fix release-please PR title pattern for scope, component, version
- 473580a refactor: move scroll logic to CommandItem

## Before Merge: Clear Stuck State

If you previously saw `There are untagged, merged release PRs outstanding - aborting`:

1. **Remove autorelease labels** from PR #28: remove `autorelease:pending` and `autorelease:tagged` if present
2. **Manually tag** if needed: `git tag v1.1.2 <merge-commit-sha>` and push, or create the GitHub Release for that commit

See [.github/RELEASE_FIX_CHECKLIST.md](.github/RELEASE_FIX_CHECKLIST.md) for details.

## Post-Merge

1. Release workflow runs on push to `main`
2. Release-please opens Release PR (e.g. `chore: release hakkaofdev.fr 1.1.2`)
3. Merge the Release PR to publish

Made with [Cursor](https://cursor.com)