### PR TITLE
Add Zustand for state management

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "react-hook-form": "^7.71.1",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+      zustand:
+        specifier: ^5.0.11
+        version: 5.0.11(@types/react@19.0.10)(react@19.2.4)
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.2
@@ -1332,6 +1335,24 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zustand@5.0.11:
+    resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -2388,3 +2409,8 @@ snapshots:
   yoga-layout@3.2.1: {}
 
   zod@4.3.6: {}
+
+  zustand@5.0.11(@types/react@19.0.10)(react@19.2.4):
+    optionalDependencies:
+      '@types/react': 19.0.10
+      react: 19.2.4


### PR DESCRIPTION
## Summary

- Add `zustand` dependency for lightweight state management
- Required for upcoming theme store and terminal session/preference stores

## Testing Checklist

- [x] `pnpm install` succeeds
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes

## Commits

```
e644af9 chore(deps): add zustand for state management
```

Made with [Cursor](https://cursor.com)