### PR TITLE
Add Zustand theme store and refactor ThemeProvider

### DIFF
--- a/components/providers/ThemeProvider.tsx
+++ b/components/providers/ThemeProvider.tsx
@@ -9,12 +9,7 @@ import {
   useState,
 } from "react";
 import { BUILTIN_THEME_MAP, BUILTIN_THEMES } from "../../lib/themes/palettes";
-import {
-  getCustomThemes,
-  getStoredThemeName,
-  removeCustomTheme,
-  storeThemeName,
-} from "../../lib/themes/storage";
+import { useThemeStore } from "../../stores/theme.store";
 import type { ThemePalette } from "../../types/theme";
 import { THEME_COLOR_KEYS } from "../../types/theme";
 
@@ -84,33 +79,18 @@ export function ThemeEngineProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [customThemes, setCustomThemes] = useState<ThemePalette[]>([]);
-  const [themeName, setThemeName] = useState<string>(DEFAULT_THEME);
+  const themeName = useThemeStore((state) => state.theme);
+  const customThemes = useThemeStore((state) => state.customThemes);
+  const setStoredTheme = useThemeStore((state) => state.setTheme);
+  const removeStoredCustomTheme = useThemeStore(
+    (state) => state.removeCustomTheme,
+  );
   const [previewName, setPreviewName] = useState<string | null>(null);
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Sync init from localStorage on mount
-  useEffect(() => {
-    const stored = getStoredThemeName();
-    const custom = getCustomThemes();
-
-    setCustomThemes(custom);
-
-    if (stored) {
-      const palette = lookupPalette(stored, custom);
-      if (palette) {
-        setThemeName(stored);
-        applyPalette(palette);
-      }
-    } else {
-      // Apply default immediately
-      const defaultPalette = BUILTIN_THEME_MAP.get(DEFAULT_THEME);
-      if (defaultPalette) applyPalette(defaultPalette);
-    }
-  }, []);
+  const resolvedCustomThemes = customThemes;
 
   const allThemes = useMemo(() => {
-    const combined = [...BUILTIN_THEMES, ...customThemes];
+    const combined = [...BUILTIN_THEMES, ...resolvedCustomThemes];
     return combined.sort((a, b) => {
       // First sort by mode: light themes first, then dark
       if (a.isDark !== b.isDark) {
@@ -119,17 +99,25 @@ export function ThemeEngineProvider({
       // Then sort alphabetically by label
       return a.label.localeCompare(b.label);
     });
-  }, [customThemes]);
+  }, [resolvedCustomThemes]);
 
   const activeName = previewName ?? themeName;
   const palette =
-    lookupPalette(activeName, customThemes) ||
+    lookupPalette(activeName, resolvedCustomThemes) ||
     BUILTIN_THEME_MAP.get(DEFAULT_THEME) ||
     BUILTIN_THEMES[0];
 
   useEffect(() => {
     applyPalette(palette);
   }, [palette]);
+
+  useEffect(() => {
+    return () => {
+      if (previewTimerRef.current) {
+        clearTimeout(previewTimerRef.current);
+      }
+    };
+  }, []);
 
   const setTheme = useCallback(
     (name: string) => {
@@ -138,33 +126,26 @@ export function ThemeEngineProvider({
         previewTimerRef.current = null;
       }
       setPreviewName(null);
-      setThemeName(name);
-      storeThemeName(name);
-
-      const p = lookupPalette(name, customThemes);
-      if (p) applyPalette(p);
+      setStoredTheme(name);
     },
-    [customThemes],
+    [setStoredTheme],
   );
 
   const previewTheme = useCallback(
     (name: string, durationMs = 10_000) => {
       if (previewTimerRef.current) clearTimeout(previewTimerRef.current);
 
-      const p = lookupPalette(name, customThemes);
+      const p = lookupPalette(name, resolvedCustomThemes);
       if (!p) return;
 
       setPreviewName(name);
-      applyPalette(p);
 
       previewTimerRef.current = setTimeout(() => {
         setPreviewName(null);
         previewTimerRef.current = null;
-        const current = lookupPalette(themeName, customThemes);
-        if (current) applyPalette(current);
       }, durationMs);
     },
-    [customThemes, themeName],
+    [resolvedCustomThemes],
   );
 
   const cancelPreview = useCallback(() => {
@@ -173,9 +154,7 @@ export function ThemeEngineProvider({
       previewTimerRef.current = null;
     }
     setPreviewName(null);
-    const current = lookupPalette(themeName, customThemes);
-    if (current) applyPalette(current);
-  }, [themeName, customThemes]);
+  }, []);
 
   const deleteCustomTheme = useCallback(
     (name: string) => {
@@ -184,24 +163,17 @@ export function ThemeEngineProvider({
         return;
       }
 
-      // Remove from storage
-      removeCustomTheme(name);
+      removeStoredCustomTheme(name);
 
-      // Update local state
-      const updated = customThemes.filter((t) => t.name !== name);
-      setCustomThemes(updated);
-
-      // If the deleted theme is currently active, switch to default
-      if (themeName === name) {
-        setTheme(DEFAULT_THEME);
-      }
-
-      // If the deleted theme is being previewed, cancel the preview
       if (previewName === name) {
-        cancelPreview();
+        if (previewTimerRef.current) {
+          clearTimeout(previewTimerRef.current);
+          previewTimerRef.current = null;
+        }
+        setPreviewName(null);
       }
     },
-    [customThemes, themeName, previewName, setTheme, cancelPreview],
+    [removeStoredCustomTheme, previewName],
   );
 
   const value = useMemo<ThemeEngineContextValue>(

--- a/lib/themes/storage.ts
+++ b/lib/themes/storage.ts
@@ -1,65 +1,32 @@
-import type { ThemePalette } from "@/types/theme";
+"use client";
 
-const THEME_KEY = "terminal-theme";
-const CUSTOM_THEMES_KEY = "terminal-custom-themes";
+import type { ThemePalette } from "@/types/theme";
+import { useThemeStore } from "@/stores/theme.store";
 
 export function getStoredThemeName(): string | null {
-  if (typeof window === "undefined") return null;
-  try {
-    return localStorage.getItem(THEME_KEY);
-  } catch {
-    return null;
-  }
+  const { theme } = useThemeStore.getState();
+  return theme ?? null;
 }
 
 export function storeThemeName(name: string): void {
-  if (typeof window === "undefined") return;
-  try {
-    localStorage.setItem(THEME_KEY, name);
-  } catch {}
+  useThemeStore.getState().setTheme(name);
 }
 
 export function getCustomThemes(): ThemePalette[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = localStorage.getItem(CUSTOM_THEMES_KEY);
-    return raw ? (JSON.parse(raw) as ThemePalette[]) : [];
-  } catch {
-    return [];
-  }
+  return useThemeStore.getState().customThemes;
 }
 
 export function storeCustomTheme(palette: ThemePalette): void {
-  if (typeof window === "undefined") return;
-  try {
-    const existing = getCustomThemes().filter((t) => t.name !== palette.name);
-    existing.push(palette);
-    localStorage.setItem(CUSTOM_THEMES_KEY, JSON.stringify(existing));
-
-    // Also store a formatted JSON version for easy export
-    const themeJsonKey = `terminal-theme-json-${palette.name}`;
-    localStorage.setItem(themeJsonKey, JSON.stringify(palette, null, 2));
-  } catch {}
+  useThemeStore.getState().upsertCustomTheme(palette);
 }
 
 export function getThemeJSON(name: string): string | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const themeJsonKey = `terminal-theme-json-${name}`;
-    return localStorage.getItem(themeJsonKey);
-  } catch {
-    return null;
-  }
+  const theme = useThemeStore
+    .getState()
+    .customThemes.find((palette) => palette.name === name);
+  return theme ? JSON.stringify(theme, null, 2) : null;
 }
 
 export function removeCustomTheme(name: string): void {
-  if (typeof window === "undefined") return;
-  try {
-    const existing = getCustomThemes().filter((t) => t.name !== name);
-    localStorage.setItem(CUSTOM_THEMES_KEY, JSON.stringify(existing));
-
-    // Also remove the JSON export
-    const themeJsonKey = `terminal-theme-json-${name}`;
-    localStorage.removeItem(themeJsonKey);
-  } catch {}
+  useThemeStore.getState().removeCustomTheme(name);
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "react-hook-form": "^7.71.1",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+      zustand:
+        specifier: ^5.0.11
+        version: 5.0.11(@types/react@19.0.10)(react@19.2.4)
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.2
@@ -1332,6 +1335,24 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zustand@5.0.11:
+    resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -2388,3 +2409,8 @@ snapshots:
   yoga-layout@3.2.1: {}
 
   zod@4.3.6: {}
+
+  zustand@5.0.11(@types/react@19.0.10)(react@19.2.4):
+    optionalDependencies:
+      '@types/react': 19.0.10
+      react: 19.2.4

--- a/stores/theme.store.ts
+++ b/stores/theme.store.ts
@@ -1,0 +1,166 @@
+"use client";
+
+import { BUILTIN_THEME_MAP } from "@/lib/themes/palettes";
+import { DEFAULT_THEME_NAME } from "@/lib/utils/terminal.utils";
+import { THEME_COLOR_KEYS, type ThemePalette } from "@/types/theme";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+const LEGACY_THEME_KEY = "terminal-theme";
+const LEGACY_CUSTOM_THEMES_KEY = "terminal-custom-themes";
+
+type PersistedThemeState = {
+  theme: string;
+  customThemes: ThemePalette[];
+};
+
+type ThemeStore = {
+  theme: string;
+  customThemes: ThemePalette[];
+  setTheme: (name: string) => void;
+  upsertCustomTheme: (palette: ThemePalette) => void;
+  removeCustomTheme: (name: string) => void;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseThemePalette(input: unknown): ThemePalette | null {
+  if (!isRecord(input)) return null;
+  if (typeof input.name !== "string") return null;
+  if (typeof input.label !== "string") return null;
+  if (typeof input.isDark !== "boolean") return null;
+  if (!isRecord(input.colors)) return null;
+
+  const colors = {} as ThemePalette["colors"];
+  for (const key of THEME_COLOR_KEYS) {
+    const value = input.colors[key];
+    if (typeof value !== "string") {
+      return null;
+    }
+    colors[key] = value;
+  }
+
+  return {
+    name: input.name,
+    label: input.label,
+    isDark: input.isDark,
+    colors,
+  };
+}
+
+function parseThemePalettes(input: unknown): ThemePalette[] {
+  if (!Array.isArray(input)) return [];
+
+  const palettes: ThemePalette[] = [];
+  for (const rawPalette of input) {
+    const parsed = parseThemePalette(rawPalette);
+    if (!parsed) continue;
+
+    const alreadyExists = palettes.some((palette) => palette.name === parsed.name);
+    if (!alreadyExists) {
+      palettes.push(parsed);
+    }
+  }
+
+  return palettes;
+}
+
+function hasTheme(name: string, customThemes: ThemePalette[]): boolean {
+  if (BUILTIN_THEME_MAP.has(name)) return true;
+  return customThemes.some((theme) => theme.name === name);
+}
+
+function resolveThemeName(name: string, customThemes: ThemePalette[]): string {
+  if (hasTheme(name, customThemes)) return name;
+  return DEFAULT_THEME_NAME;
+}
+
+function parsePersistedThemeState(input: unknown): PersistedThemeState | null {
+  if (!isRecord(input)) return null;
+
+  const customThemes = parseThemePalettes(input.customThemes);
+  const theme =
+    typeof input.theme === "string"
+      ? resolveThemeName(input.theme, customThemes)
+      : DEFAULT_THEME_NAME;
+
+  return { theme, customThemes };
+}
+
+function loadLegacyThemeState(): PersistedThemeState | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const rawThemeName = localStorage.getItem(LEGACY_THEME_KEY);
+    const rawCustomThemes = localStorage.getItem(LEGACY_CUSTOM_THEMES_KEY);
+    const customThemes = rawCustomThemes
+      ? parseThemePalettes(JSON.parse(rawCustomThemes))
+      : [];
+    const theme = resolveThemeName(rawThemeName ?? DEFAULT_THEME_NAME, customThemes);
+
+    return { theme, customThemes };
+  } catch {
+    return null;
+  }
+}
+
+export const useThemeStore = create<ThemeStore>()(
+  persist(
+    (set) => ({
+      theme: DEFAULT_THEME_NAME,
+      customThemes: [],
+      setTheme: (name) =>
+        set((state) => {
+          if (!hasTheme(name, state.customThemes)) return state;
+          if (state.theme === name) return state;
+          return { theme: name };
+        }),
+      upsertCustomTheme: (palette) =>
+        set((state) => {
+          const parsedPalette = parseThemePalette(palette);
+          if (!parsedPalette) return state;
+
+          return {
+            customThemes: [
+              ...state.customThemes.filter(
+                (theme) => theme.name !== parsedPalette.name,
+              ),
+              parsedPalette,
+            ],
+          };
+        }),
+      removeCustomTheme: (name) =>
+        set((state) => {
+          const customThemes = state.customThemes.filter(
+            (theme) => theme.name !== name,
+          );
+          if (customThemes.length === state.customThemes.length) return state;
+
+          return {
+            customThemes,
+            theme: resolveThemeName(state.theme, customThemes),
+          };
+        }),
+    }),
+    {
+      name: "terminal-theme-store",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        theme: state.theme,
+        customThemes: state.customThemes,
+      }),
+      merge: (persistedState, currentState) => {
+        const parsedPersisted = parsePersistedThemeState(persistedState);
+        if (parsedPersisted) {
+          return { ...currentState, ...parsedPersisted };
+        }
+
+        const legacyState = loadLegacyThemeState();
+        if (!legacyState) return currentState;
+        return { ...currentState, ...legacyState };
+      },
+    },
+  ),
+);


### PR DESCRIPTION
## Summary

- Add `stores/theme.store.ts` with persist middleware and legacy localStorage migration
- Refactor ThemeProvider to use `useThemeStore` from Zustand
- Simplify `lib/themes/storage.ts` (storage logic moved to store)

**Note:** This PR is based on `chore/deps-zustand` (PR #35). Merge PR #35 first, then rebase this branch onto `develop` before merging to avoid duplicate commits.

## Commits

```
fc83b46 feat(theme): add Zustand theme store and refactor ThemeProvider
e644af9 chore(deps): add zustand for state management
```

Made with [Cursor](https://cursor.com)