### PR TITLE
feat(cv): link experiences to companies and refresh resume copy

### DIFF
--- a/components/commands/renders/CExperiences.tsx
+++ b/components/commands/renders/CExperiences.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { AnimatedSpan } from "@/components/AnimatedComponents";
 import { EXPERIENCES } from "@/lib/constants";
 import { cn } from "@/lib/utils";
@@ -20,7 +21,19 @@ function CExperiences() {
           <p className="text-muted-foreground">{experience.period}</p>
           <p className="font-semibold text-sm">{experience.name}</p>
           <p className="text-muted-foreground">
-            {experience.company} · {experience.location}
+            {experience.companyUrl ? (
+              <Link
+                href={experience.companyUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="underline-offset-2 hover:text-primary hover:underline"
+              >
+                {experience.company}
+              </Link>
+            ) : (
+              experience.company
+            )}{" "}
+            · {experience.location}
           </p>
           {experience.descriptions && experience.descriptions?.length > 0 && (
             <ul className="mt-2 list-disc pl-4">

--- a/components/commands/renders/CProjects.tsx
+++ b/components/commands/renders/CProjects.tsx
@@ -6,20 +6,18 @@ import { PROJECTS } from "@/lib/constants";
 function CProjects() {
   return (
     <AnimatedSpan className="grid grid-cols-1 gap-4 md:grid-cols-2">
-      {PROJECTS.map((project) => (
-        <Link
-          href={project.url}
-          key={project.name}
-          aria-label={`Open project: ${project.name}`}
-          target="_blank"
-          className="group h-auto"
-        >
+      {PROJECTS.map((project) => {
+        const content = (
           <div className="flex h-full flex-col overflow-hidden rounded-lg border">
             <div className="relative aspect-video overflow-hidden">
               <Image
                 src={project.imageUrl}
                 alt={project.name}
-                className="object-cover transition-all duration-300 group-hover:scale-105"
+                className={
+                  project.url
+                    ? "object-cover transition-all duration-300 group-hover:scale-105"
+                    : "object-cover"
+                }
                 fill
               />
             </div>
@@ -42,8 +40,28 @@ function CProjects() {
               </div>
             </div>
           </div>
-        </Link>
-      ))}
+        );
+
+        if (!project.url) {
+          return (
+            <div key={project.name} className="h-auto">
+              {content}
+            </div>
+          );
+        }
+
+        return (
+          <Link
+            href={project.url}
+            key={project.name}
+            aria-label={`Open project: ${project.name}`}
+            target="_blank"
+            className="group h-auto"
+          >
+            {content}
+          </Link>
+        );
+      })}
     </AnimatedSpan>
   );
 }

--- a/components/cv-pdf/CVDocument.tsx
+++ b/components/cv-pdf/CVDocument.tsx
@@ -14,7 +14,7 @@ import {
 export function CVDocument() {
   return (
     <Document
-      title={`${CV_DATA.name} — CV`}
+      title={`${CV_DATA.name} - CV`}
       author={CV_DATA.name}
       subject="CV"
       creator="hakkaofdev.fr"

--- a/components/cv-pdf/CVSections.tsx
+++ b/components/cv-pdf/CVSections.tsx
@@ -74,7 +74,14 @@ export function ExperienceSection({
             <Text style={styles.itemPeriod}>{exp.period}</Text>
           </View>
           <View style={styles.itemSubRow}>
-            <Text style={styles.itemCompany}>{exp.company}</Text>
+            <View style={styles.itemCompanyGroup}>
+              <Text style={styles.itemCompany}>{exp.company}</Text>
+              {exp.companyUrl && (
+                <Link src={exp.companyUrl} style={styles.itemCompanyLink}>
+                  {exp.companyUrl.replace(/^https?:\/\/(www\.)?/, "")}
+                </Link>
+              )}
+            </View>
             <Text style={styles.itemLocation}>{exp.location}</Text>
           </View>
           {exp.descriptions.map((desc) => (
@@ -141,9 +148,11 @@ export function ProjectsSection({
         <View key={project.name} style={styles.projectItem}>
           <View style={styles.projectHeader}>
             <Text style={styles.projectName}>{project.name}</Text>
-            <Link src={project.url} style={styles.projectLink}>
-              {project.url.replace(/^https?:\/\/(www\.)?/, "")}
-            </Link>
+            {project.url && (
+              <Link src={project.url} style={styles.projectLink}>
+                {project.url.replace(/^https?:\/\/(www\.)?/, "")}
+              </Link>
+            )}
           </View>
           <Text style={styles.projectTags}>{project.tags.join("  ·  ")}</Text>
           <Text style={styles.projectDesc}>{project.description}</Text>
@@ -168,7 +177,7 @@ export function BottomSection({
         <Section title="Languages">
           {languages.map((lang) => (
             <Text key={lang.lang} style={styles.langLine}>
-              <Text style={styles.langBold}>{lang.lang}</Text> — {lang.level}
+              <Text style={styles.langBold}>{lang.lang}</Text> - {lang.level}
             </Text>
           ))}
         </Section>

--- a/lib/constants/projects.constants.ts
+++ b/lib/constants/projects.constants.ts
@@ -39,10 +39,16 @@ export const PROJECTS = [
     tags: ["Next.js", "Tailwind", "Typescript", "Freelance"],
   },
   {
+    name: "AC-Vision",
+    description: "DASAN OLT/ONUs Supervision tool [Opensource].",
+    url: "https://github.com/hakkaofdev/ac-vision",
+    imageUrl: "/projects/ac-vision.png",
+    tags: ["Next.js", "Python", "Typescript", "Redis", "Docker", "Open-source"],
+  },
+  {
     name: "Brian Grav&Style",
     description:
       "A custom e-commerce platform for a professional engraving studio, featuring a product catalog, online ordering and an admin dashboard for order management.",
-    url: "https://brian-gravure.vercel.app",
     imageUrl: "/projects/brian-gravure.png",
     tags: ["Next.js", "Tailwind", "Typescript", "E-commerce"],
   },
@@ -61,13 +67,6 @@ export const PROJECTS = [
     url: "https://ts-next-chakra-motion-kit.vercel.app",
     imageUrl: "/projects/ts-next-chakra-motion-kit.png",
     tags: ["Next.js", "Chakra UI", "Typescript", "Template", "Open-source"],
-  },
-  {
-    name: "AC-Vision",
-    description: "DASAN OLT/ONUs Supervision tool [Opensource].",
-    url: "https://github.com/hakkaofdev/ac-vision",
-    imageUrl: "/projects/ac-vision.png",
-    tags: ["Next.js", "Python", "Typescript", "Redis", "Docker", "Open-source"],
   },
   {
     name: "RT'ransport",

--- a/lib/constants/resume.constants.ts
+++ b/lib/constants/resume.constants.ts
@@ -1,3 +1,5 @@
+import { SITE } from "./site.constants";
+
 export const EDUCATION = [
   {
     period: "2022-2023",
@@ -25,41 +27,42 @@ export const EXPERIENCES = [
   {
     period: "Since July 2022",
     name: "Software Engineer",
-    company: "kabila.app",
+    company: "Kabila",
+    companyUrl: "https://kabila.app",
     location: "Madrid, Spain",
     descriptions: [
-      "Leading a team to deliver high-quality web applications",
-      "Implementing modern frontend architecture and best practices",
-      "Managing technical roadmap and sprint planning",
-      "Mentoring junior developers and conducting code reviews",
-      "Building reusable component libraries and design systems",
-      "Creating mobile apps with React Native and Expo",
+      "Lead a frontend team building production web apps with React and Next.js",
+      "Own the technical roadmap, sprint planning, and architecture decisions",
+      "Mentor junior developers and run code reviews",
+      "Build and maintain the shared component library and internal design system",
+      "Ship companion mobile apps with React Native and Expo",
     ],
   },
   {
     period: "Since July 2022",
     name: "Freelance",
     company: "Alexandre GOSSARD",
+    companyUrl: SITE.url,
     location: "Châlons-en-Champagne, France",
     descriptions: [
-      "Developed full-stack web applications using React and Next.js",
-      "Built cross-platform mobile apps with React Native and Expo",
-      "Implemented CI/CD pipelines and automated deployment workflows",
-      "Provided technical consulting and architecture recommendations",
-      "Managed client relationships and project timelines independently",
-      "Delivering mobile apps for clients on the Google Play Store and Apple App Store",
+      "Build full-stack web apps with React and Next.js for direct clients",
+      "Ship cross-platform mobile apps to the App Store and Google Play",
+      "Set up CI/CD pipelines and automated deployment workflows",
+      "Advise on architecture, tech choices, and project scoping",
+      "Handle client communication and delivery timelines on every project",
     ],
   },
   {
     period: "September 2022 - August 2023",
     name: "Apprenticeship",
     company: "Arche MC2",
+    companyUrl: "https://arche-mc2.fr",
     location: "Châlons-en-Champagne, France",
     descriptions: [
-      "Implemented GitLab CI/CD pipelines for automated testing and deployment",
-      "Managed Docker containerization of applications and services",
-      "Automated system administration tasks using shell scripts",
-      "Monitored system health and implemented scalable solutions",
+      "Built GitLab CI/CD pipelines for automated testing and deployment",
+      "Containerized internal applications and services with Docker",
+      "Automated routine sysadmin tasks with shell scripts",
+      "Monitored system health and improved infrastructure resilience",
     ],
   },
 ];

--- a/lib/cv/cv-pdf.data.ts
+++ b/lib/cv/cv-pdf.data.ts
@@ -25,7 +25,8 @@ export const CV_DATA = {
   website: SITE.url,
   email: SITE.email,
   location: SITE.location,
-  summary: SITE.description,
+  summary:
+    "Software Engineer, nearly four years in. I freelance for my own clients, building web and mobile apps that ship to real users on the App Store and Google Play. React, Next.js and React Native are home turf, with a soft spot for clean architecture, quick feedback loops, and the occasional open-source side project. Based in France, working from wherever the laptop fits.",
   socials: SOCIALS.map((social) => ({
     name: social.name,
     url: social.url,
@@ -40,6 +41,7 @@ export const CV_DATA = {
     period: experience.period,
     title: experience.name,
     company: experience.company,
+    companyUrl: experience.companyUrl,
     location: experience.location,
     descriptions: experience.descriptions ?? [],
   })),

--- a/lib/cv/cv-pdf.styles.ts
+++ b/lib/cv/cv-pdf.styles.ts
@@ -116,10 +116,20 @@ export const styles = StyleSheet.create({
     alignItems: "baseline",
     marginBottom: 2,
   },
+  itemCompanyGroup: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 6,
+  },
   itemCompany: {
     fontSize: 9.5,
     color: COLORS.dark,
     fontFamily: "Helvetica-Oblique",
+  },
+  itemCompanyLink: {
+    fontSize: 8.5,
+    color: COLORS.accent,
+    textDecoration: "none",
   },
   itemLocation: {
     fontSize: 9,


### PR DESCRIPTION
## Summary

- Experiences now carry an optional `companyUrl`, surfaced as a link in the terminal `experiences` command and as a small accent link in the generated CV PDF.
- Projects no longer require a public URL — entries without one render as plain cards (no hover scale, no `<Link>` wrapper) in both the terminal view and the PDF.
- Experience bullets and the CV summary were rewritten in a tighter, more personal voice; `kabila.app` is now displayed as **Kabila** with the URL exposed via the new link slot.
- Em-dashes (`—`) replaced with hyphens (`-`) in PDF strings to avoid Helvetica glyph fallbacks in `@react-pdf/renderer`.
- AC-Vision moved up the projects list to sit with current work; Brian Grav&Style URL removed (site is no longer public).

## Changes

| Area | File |
| --- | --- |
| Terminal view | `components/commands/renders/CExperiences.tsx`, `components/commands/renders/CProjects.tsx` |
| PDF renderer | `components/cv-pdf/CVDocument.tsx`, `components/cv-pdf/CVSections.tsx`, `lib/cv/cv-pdf.data.ts`, `lib/cv/cv-pdf.styles.ts` |
| Data | `lib/constants/resume.constants.ts`, `lib/constants/projects.constants.ts` |

## Test plan

- [x] `experiences` command renders Kabila / Arche MC2 / Freelance with clickable company names (new tab, `rel="noreferrer"`)
- [x] `experiences` still renders cleanly for any entry without a `companyUrl`
- [x] `projects` command opens external sites for entries with a URL and renders a non-interactive card for entries without one
- [x] CV PDF download shows the company URL next to the company name and falls back gracefully when missing
- [x] CV PDF projects section omits the link line for projects without a URL
- [x] No em-dash glyph fallbacks in the generated PDF (title, languages section)