### PR TITLE
fix(security): CSP, HSTS, hardened headers, prod source maps

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -3,12 +3,14 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata, Viewport } from "next";
 import { JetBrains_Mono } from "next/font/google";
 import { notFound } from "next/navigation";
+import Script from "next/script";
 import { hasLocale, NextIntlClientProvider } from "next-intl";
 import {
   getMessages,
   getTranslations,
   setRequestLocale,
 } from "next-intl/server";
+import { useId } from "react";
 import Footer from "@/components/Footer";
 import Providers from "@/components/providers/Providers";
 import { getScriptFontVariable } from "@/i18n/fonts";
@@ -29,6 +31,15 @@ const siteUrl = getSiteUrl();
 const twitterHandle = `@${SITE.handle}` as const;
 
 type Params = { locale: string };
+
+function PersonJsonLd({ data }: { data: object }) {
+  const id = useId();
+  return (
+    <Script id={id} type="application/ld+json" strategy="beforeInteractive">
+      {JSON.stringify(data).replace(/</g, "\\u003c")}
+    </Script>
+  );
+}
 
 function buildOpenGraphImagePath(locale: string) {
   return locale === routing.defaultLocale
@@ -170,10 +181,7 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
           "flex h-[100dvh] flex-col overflow-hidden antialiased",
         )}
       >
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
-        />
+        <PersonJsonLd data={personJsonLd} />
         <NextIntlClientProvider messages={messages}>
           <Providers>
             {children}

--- a/lib/services/github.ts
+++ b/lib/services/github.ts
@@ -14,7 +14,7 @@ const REPOS_PER_PAGE = 100;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-/** Builds common GitHub REST API headers with optional Bearer auth. */
+/** Builds common GitHub REST API headers, attaching the token from env when present. */
 function githubHeaders(): HeadersInit {
   const token = process.env.GITHUB_TOKEN;
   return {

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,24 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 
+const isDev = process.env.NODE_ENV !== "production";
+
+const cspDirectives = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "img-src 'self' data: blob: https://i.scdn.co",
+  "font-src 'self' data: https://fonts.gstatic.com",
+  `connect-src 'self'${isDev ? " ws: wss:" : ""}`,
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+  "upgrade-insecure-requests",
+].join("; ");
+
 const nextConfig: NextConfig = {
+  productionBrowserSourceMaps: true,
   experimental: {
     inlineCss: true,
     optimizePackageImports: ["lucide-react", "date-fns"],
@@ -17,6 +34,35 @@ const nextConfig: NextConfig = {
         protocol: "https",
       },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: cspDirectives,
+          },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+    ];
   },
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,7 @@ const cspDirectives = [
 
 const nextConfig: NextConfig = {
   productionBrowserSourceMaps: true,
+  poweredByHeader: false,
   experimental: {
     inlineCss: true,
     optimizePackageImports: ["lucide-react", "date-fns"],
@@ -43,6 +44,10 @@ const nextConfig: NextConfig = {
           {
             key: "Content-Security-Policy",
             value: cspDirectives,
+          },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
           },
           {
             key: "Referrer-Policy",


### PR DESCRIPTION
## Summary
- Adds a Content-Security-Policy and supporting hardening headers (HSTS, Referrer-Policy, X-Content-Type-Options, X-Frame-Options, Permissions-Policy) via `next.config.ts` `headers()`.
- Disables the `X-Powered-By` header (`poweredByHeader: false`).
- Switches the JSON-LD `<script>` to `next/script` with `<` escaped to `<` to prevent script-tag breakout from data.
- Enables `productionBrowserSourceMaps: true` so Lighthouse no longer flags missing first-party source maps.

## CSP scope
- `default-src 'self'`
- `script-src 'self' 'unsafe-inline'` — Next.js hydration + `next-themes` anti-flash inline scripts. Dev adds `'unsafe-eval'` for HMR.
- `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com` — inline styles from Tailwind/Radix; Google Fonts CSS pulled by `DeferredFontLoader`.
- `img-src 'self' data: blob: https://i.scdn.co` — Spotify album art (matches `next.config.ts` remote pattern).
- `font-src 'self' data: https://fonts.gstatic.com` — actual woff2 files from Google Fonts.
- `connect-src 'self'` — Supabase is server-only (service-role key); Vercel Analytics + Speed Insights are proxied same-origin via `/_vercel/insights/*`. Dev adds `ws: wss:` for HMR.
- Plus `frame-ancestors 'none'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, `upgrade-insecure-requests`.

## Other hardening
- **HSTS**: `max-age=63072000; includeSubDomains; preload` — 2-year max-age, eligible for the preload list.
- **X-Powered-By off**: removes the `Next.js` fingerprint from responses.
- **JSON-LD**: rendered via `next/script` with `</` escaped, avoiding the classic `</script>` injection vector if any field ever contains user-controlled data.

## Notes
- `'unsafe-inline'` for `script-src` could be eliminated with a nonce-based middleware approach — left as a follow-up since it's more invasive.
- `productionBrowserSourceMaps` exposes minified→source mapping in the browser; fine for a personal site, slightly larger upload.

## Test plan
- [x] `pnpm build` succeeds locally.
- [x] `pnpm typecheck` clean.
- [x] Verify Vercel preview returns the CSP + HSTS headers on `/`.
- [x] Lighthouse re-run on preview: Issues panel no longer flags CSP, source-maps audit no longer warns.
- [x] Smoke check: Spotify card images load, Google Fonts (Montserrat / Fira Code / Source Code Pro) load, no console CSP violations.