### PR TITLE
feat(analytics): exclude bot user-agents from unique-visitor counts

### DIFF
--- a/app/api/views/route.ts
+++ b/app/api/views/route.ts
@@ -4,6 +4,7 @@ import {
   extractCountry,
   extractIpAddress,
   hashIpAddress,
+  isBotUserAgent,
 } from "@/lib/utils/request.utils";
 
 export const runtime = "nodejs";
@@ -25,9 +26,14 @@ export async function POST(request: Request) {
     return Response.json({ error: "Analytics unavailable." }, { status: 503 });
   }
 
+  const userAgent = request.headers.get("user-agent")?.slice(0, 255) ?? null;
+
+  if (isBotUserAgent(userAgent)) {
+    return Response.json({ ok: true, is_new: false });
+  }
+
   const ipHash = hashIpAddress(extractIpAddress(request)) ?? "unknown";
   const country = extractCountry(request);
-  const userAgent = request.headers.get("user-agent")?.slice(0, 255) ?? null;
 
   const { data, error } = await supabase.rpc("record_visit", {
     p_slug: HOME_SLUG,

--- a/lib/utils/request.utils.ts
+++ b/lib/utils/request.utils.ts
@@ -26,3 +26,12 @@ export function extractCountry(request: Request): string | null {
     null
   );
 }
+
+const BOT_USER_AGENT_PATTERN =
+  /bot|crawl(?:er|ing)?|spider|slurp|mediapartners|facebookexternalhit|whatsapp|telegram|discord|slack|linkedin|twitter|pinterest|embedly|preview|fetch|monitor|pingdom|gtmetrix|lighthouse|pagespeed|chrome-lighthouse|headless|phantomjs|puppeteer|playwright|selenium|axios|curl|wget|python-requests|node-fetch|go-http-client|java\/|okhttp/i;
+
+/** Returns true when the User-Agent looks like a bot, crawler, or automated client. */
+export function isBotUserAgent(userAgent: string | null | undefined): boolean {
+  if (!userAgent) return true;
+  return BOT_USER_AGENT_PATTERN.test(userAgent);
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,6 +7,7 @@ import {
   extractCountry,
   extractIpAddress,
   hashIpAddress,
+  isBotUserAgent,
 } from "@/lib/utils/request.utils";
 
 const intlMiddleware = createMiddleware(routing);
@@ -32,7 +33,7 @@ export function proxy(request: NextRequest) {
         request.headers.get("user-agent")?.slice(0, 255) ?? null;
 
       after(async () => {
-        if (!ipHash) return;
+        if (!ipHash || isBotUserAgent(userAgent)) return;
 
         const supabase = createClient(url, key);
         try {


### PR DESCRIPTION
## Summary

- Add `isBotUserAgent` in `lib/utils/request.utils.ts` covering common crawlers (Googlebot/Bingbot/Yandex/…), social previewers (Slack/Discord/Twitter/LinkedIn/WhatsApp/Telegram), monitoring tools (Pingdom/Lighthouse/PageSpeed), headless browsers (Puppeteer/Playwright/PhantomJS), and HTTP libraries (curl/wget/axios/python-requests/okhttp). Missing UA is treated as a bot.
- `proxy.ts` skips the `record_visit` RPC inside `after()` when the UA looks like a bot, alongside the existing `!ipHash` guard.
- `app/api/views/route.ts` POST returns `{ ok: true, is_new: false }` for bot UAs so the response shape doesn't disclose the filter.
- No new dependency.

## Notes

- Existing rows in `visitors` from past bot hits stay where they are; cleaning historical data is intentionally out of scope.
- If broader coverage is needed later, swapping in [`isbot`](https://www.npmjs.com/package/isbot) is a one-import change.

## Test plan

- [x] `pnpm typecheck` passes
- [x] In production, `curl https://hakkaofdev.fr/` (default curl UA) does not increment `unique_visitors`
- [x] Real browser hits still increment the counter
- [x] `POST /api/views` with `User-Agent: Googlebot/2.1` returns 200 `{ ok: true, is_new: false }` and writes nothing to `visitors`
- [x] `POST /api/views` with no `User-Agent` header is also treated as a bot