### PR TITLE
chore(i18n): standardise ellipsis and em-dash, polish copy

### DIFF
--- a/components/commands/renders/guestbook/read/CGuestbookRead.tsx
+++ b/components/commands/renders/guestbook/read/CGuestbookRead.tsx
@@ -36,7 +36,7 @@ function CGuestbookRead() {
       <div className="flex items-center justify-between gap-3">
         <p className="font-mono text-muted-foreground text-xs">
           <span className="font-semibold text-quinary">{t("headerLabel")}</span>
-          <span className="text-muted-foreground/40"> — </span>
+          <span className="text-muted-foreground/40"> - </span>
           {data ? t("entry", { count: data.length }) : t("unavailable")}
         </p>
         <div className="flex items-center gap-1.5">

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1,7 +1,4 @@
 {
-  "_meta": {
-    "needsReview": true
-  },
   "Metadata": {
     "title": "ألكسندر غوسار | رحالة رقمي ومهندس برمجيات",
     "description": "رحالة رقمي ومهندس برمجيات مستقل. شغوف بالمصادر المفتوحة، أصمم تجارب ويب عالية الأداء بـ React و Next.js.",
@@ -26,10 +23,10 @@
   },
   "Welcome": {
     "greeting": "~ مرحبًا <wave>👋</wave>",
-    "intro": "<tagline>رحالة رقمي</tagline> · <job>مهندس برمجيات</job> · <freelance>عمل حر</freelance>",
+    "intro": "<tagline>رحالة رقمي</tagline> · <job>مهندس برمجيات</job> · <freelance>مستقل</freelance>",
     "tags": {
       "openSource": "مناصر للمصادر المفتوحة",
-      "calisthenics": "محب لتمارين الكاليستينك",
+      "calisthenics": "محب لتمارين الكاليستنكس",
       "stack": "React · Next.js"
     },
     "sections": {
@@ -110,7 +107,7 @@
       "sudo rm -rf / ؟ مم… لا.",
       "هل ظننت حقًا أن ذلك سينجح؟",
       "إغلاقي؟ في هذا الزمن؟",
-      "لقد صُنعت بشكل مختلف. جرّب «contact»."
+      "أنا من طينة مختلفة. جرّب «contact»."
     ]
   },
   "Commands": {
@@ -137,7 +134,7 @@
       "clear": "مسح جميع الأوامر والمخرجات السابقة",
       "reset": "إعادة الطرفية إلى شاشة الترحيب",
       "stats": "نشاط البرمجة، GitHub وعدد الزوار",
-      "repo": "فتح الكود المصدري لهذه المعرض",
+      "repo": "فتح الكود المصدري لمعرض الأعمال هذا",
       "echo": "طباعة رسالة في الطرفية",
       "spotifyNow": "عرض الأغنية المُشغّلة الآن",
       "spotifyTop": "عرض المقطوعات المفضلة",
@@ -199,7 +196,7 @@
     },
     "repo": {
       "starsLabel": "النجوم",
-      "forksLabel": "Forks",
+      "forksLabel": "التفرعات",
       "licenseLabel": "الترخيص",
       "copyAria": "نسخ إلى الحافظة",
       "copy": "نسخ",
@@ -207,7 +204,7 @@
       "copiedNotice": "تم النسخ!",
       "copyFailedAria": "فشل النسخ",
       "copyFailedNotice": "حاول مجددًا",
-      "fallback": "الكود المصدري لهذه المحفظة متاح هنا:"
+      "fallback": "الكود المصدري لمعرض الأعمال هذا متاح هنا:"
     },
     "cv": {
       "openPreview": "فتح معاينة PDF",
@@ -356,8 +353,8 @@
     "noArgs": "{command} لا يقبل وسائط.",
     "missingName": "اسم السمة مفقود.",
     "tooManyArgs": "وسائط كثيرة جدًا.",
-    "usageSet": "الاستخدام: theme set <اسم>",
-    "usagePreview": "الاستخدام: theme preview <اسم>",
+    "usageSet": "الاستخدام: theme set '<name>'",
+    "usagePreview": "الاستخدام: theme preview '<name>'",
     "unknownSubcommand": "أمر فرعي غير معروف: {sub}. استخدم واحدًا من: {commands}.",
     "list": {
       "available": "السمات المتاحة ({count}):",
@@ -375,7 +372,7 @@
       "unknown": "سمة غير معروفة: {name}.",
       "runListHint": "نفّذ <link></link> لرؤية السمات المتاحة.",
       "previewing": "معاينة {label}",
-      "autoReverts": "— يرجع تلقائيًا خلال {seconds} ثانية",
+      "autoReverts": "- يرجع تلقائيًا خلال {seconds} ثانية",
       "applyHintPrefix": "استخدم",
       "applyHintSuffix": "للتطبيق بشكل دائم."
     },

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -1,7 +1,4 @@
 {
-  "_meta": {
-    "needsReview": true
-  },
   "Metadata": {
     "title": "Alexandre Gossard | Digitální nomád a softwarový inženýr",
     "description": "Digitální nomád a softwarový inženýr na volné noze. Nadšenec open source, tvořím výkonné webové aplikace v React a Next.js.",
@@ -41,7 +38,7 @@
     }
   },
   "Terminal": {
-    "noMatch": "Žádný příkaz neodpovídá „{query}\".",
+    "noMatch": "Žádný příkaz neodpovídá „{query}“.",
     "header": {
       "resetTitle": "Resetovat terminál (Ctrl+R)",
       "resetLabel": "Resetovat terminál",
@@ -104,13 +101,13 @@
     },
     "closeMessages": [
       "Hezký pokus! Nemůžeš mě zavřít.",
-      "Nikam nejdu. Zkus „help\"!",
+      "Nikam nejdu. Zkus „help“!",
       "Ne. Tento terminál má problémy s důvěrou v tlačítka pro zavření.",
       "Chyba 418: jsem konvička, ne zavíratelné okno.",
       "sudo rm -rf / ? Hmm… ne.",
       "Vážně sis myslel, že to bude fungovat?",
       "Zavřít mě? V této době?",
-      "Jsem postaven jinak. Zkus „contact\"."
+      "Jsem zkrátka jiný. Zkus „contact“."
     ]
   },
   "Commands": {
@@ -356,8 +353,8 @@
     "noArgs": "{command} nepřijímá argumenty.",
     "missingName": "Chybí název motivu.",
     "tooManyArgs": "Příliš mnoho argumentů.",
-    "usageSet": "Použití: theme set <název>",
-    "usagePreview": "Použití: theme preview <název>",
+    "usageSet": "Použití: theme set '<name>'",
+    "usagePreview": "Použití: theme preview '<name>'",
     "unknownSubcommand": "Neznámý podpříkaz: {sub}. Použijte jednu z: {commands}.",
     "list": {
       "available": "Dostupné motivy ({count}):",
@@ -375,7 +372,7 @@
       "unknown": "Neznámé téma: {name}.",
       "runListHint": "Spusťte <link></link> pro zobrazení dostupných témat.",
       "previewing": "Náhled {label}",
-      "autoReverts": "— vrátí se za {seconds} s",
+      "autoReverts": "- vrátí se za {seconds} s",
       "applyHintPrefix": "Použijte",
       "applyHintSuffix": "pro trvalé použití."
     },

--- a/messages/de.json
+++ b/messages/de.json
@@ -38,7 +38,7 @@
     }
   },
   "Terminal": {
-    "noMatch": "Kein Befehl entspricht „{query}\".",
+    "noMatch": "Kein Befehl entspricht „{query}“.",
     "header": {
       "resetTitle": "Terminal zurücksetzen (Strg+R)",
       "resetLabel": "Terminal zurücksetzen",
@@ -101,13 +101,13 @@
     },
     "closeMessages": [
       "Netter Versuch! Du kannst mich nicht schließen.",
-      "Ich gehe nirgendwohin. Versuch's mal mit „help\"!",
-      "Nope. Dieses Terminal hat Vertrauensprobleme mit Schließen-Buttons.",
+      "Ich gehe nirgendwohin. Versuch's mal mit „help“!",
+      "Nö. Dieses Terminal traut Schließen-Buttons nicht.",
       "Fehler 418: Ich bin eine Teekanne, kein schließbares Fenster.",
       "sudo rm -rf / ? Ähm… nein.",
       "Hast du wirklich gedacht, das funktioniert?",
-      "Mich schließen? In dieser Wirtschaftslage?",
-      "Ich bin anders gebaut. Versuch's mal mit „contact\"."
+      "Mich schließen? Bei der Wirtschaftslage?",
+      "Ich bin anders gebaut. Versuch's mal mit „contact“."
     ]
   },
   "Commands": {
@@ -504,8 +504,8 @@
     "noArgs": "{command} akzeptiert keine Argumente.",
     "missingName": "Theme-Name fehlt.",
     "tooManyArgs": "Zu viele Argumente.",
-    "usageSet": "Verwendung: theme set <Name>",
-    "usagePreview": "Verwendung: theme preview <Name>",
+    "usageSet": "Verwendung: theme set '<name>'",
+    "usagePreview": "Verwendung: theme preview '<name>'",
     "unknownSubcommand": "Unbekannter Unterbefehl: {sub}. Verwende eine dieser Optionen: {commands}.",
     "list": {
       "available": "Verfügbare Themes ({count}):",
@@ -518,7 +518,7 @@
       "unknown": "Unbekanntes Theme: {name}.",
       "runListHint": "Führe <link></link> aus, um verfügbare Themes zu sehen.",
       "previewing": "Vorschau für {label}",
-      "autoReverts": "— wird in {seconds}s automatisch zurückgesetzt",
+      "autoReverts": "- wird in {seconds}s automatisch zurückgesetzt",
       "applyHintPrefix": "Verwende",
       "applyHintSuffix": "zum dauerhaften Anwenden."
     },
@@ -577,11 +577,11 @@
       "tryAgain": "Erneut versuchen",
       "errors": {
         "nameAndLabelRequired": "Theme-Name und -Label sind Pflicht.",
-        "missingNameField": "Pflichtfeld „name\" (string) fehlt.",
-        "missingLabelField": "Pflichtfeld „label\" (string) fehlt.",
-        "missingIsDarkField": "Pflichtfeld „isDark\" (boolean) fehlt.",
-        "missingColorsField": "Pflichtfeld „colors\" (object) fehlt.",
-        "missingColor": "Fehlende oder ungültige Farbe: „{key}\".",
+        "missingNameField": "Pflichtfeld „name“ (string) fehlt.",
+        "missingLabelField": "Pflichtfeld „label“ (string) fehlt.",
+        "missingIsDarkField": "Pflichtfeld „isDark“ (boolean) fehlt.",
+        "missingColorsField": "Pflichtfeld „colors“ (object) fehlt.",
+        "missingColor": "Fehlende oder ungültige Farbe: „{key}“.",
         "invalidJson": "Ungültige JSON-Eingabe.",
         "invalidData": "Ungültige Theme-Daten."
       },

--- a/messages/el.json
+++ b/messages/el.json
@@ -1,7 +1,4 @@
 {
-  "_meta": {
-    "needsReview": true
-  },
   "Metadata": {
     "title": "Alexandre Gossard | Ψηφιακός νομάδας & μηχανικός λογισμικού",
     "description": "Ψηφιακός νομάδας και freelance μηχανικός λογισμικού. Λάτρης του open source, δημιουργώ γρήγορες εμπειρίες ιστού με React και Next.js.",
@@ -356,8 +353,8 @@
     "noArgs": "Η {command} δεν δέχεται ορίσματα.",
     "missingName": "Λείπει το όνομα του θέματος.",
     "tooManyArgs": "Πάρα πολλά ορίσματα.",
-    "usageSet": "Χρήση: theme set <όνομα>",
-    "usagePreview": "Χρήση: theme preview <όνομα>",
+    "usageSet": "Χρήση: theme set '<name>'",
+    "usagePreview": "Χρήση: theme preview '<name>'",
     "unknownSubcommand": "Άγνωστη υποεντολή: {sub}. Χρησιμοποιήστε μία από: {commands}.",
     "list": {
       "available": "Διαθέσιμα θέματα ({count}):",
@@ -375,7 +372,7 @@
       "unknown": "Άγνωστο θέμα: {name}.",
       "runListHint": "Εκτελέστε <link></link> για να δείτε τα διαθέσιμα θέματα.",
       "previewing": "Προεπισκόπηση {label}",
-      "autoReverts": "— επιστροφή σε {seconds} δ.",
+      "autoReverts": "- επιστροφή σε {seconds} δ.",
       "applyHintPrefix": "Χρησιμοποιήστε",
       "applyHintSuffix": "για μόνιμη εφαρμογή."
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -59,11 +59,11 @@
       "limitReached": "Session limit reached"
     },
     "search": {
-      "placeholder": "Filter command history...",
+      "placeholder": "Filter command history…",
       "hide": "Hide search"
     },
     "input": {
-      "placeholder": "type a command...",
+      "placeholder": "type a command…",
       "submit": "Submit command"
     },
     "fontSize": {
@@ -104,7 +104,7 @@
       "I'm not going anywhere. Try 'help' instead!",
       "Nope. This terminal has trust issues with close buttons.",
       "Error 418: I'm a teapot, not a closable window.",
-      "sudo rm -rf / ? Yeah... no.",
+      "sudo rm -rf / ? Yeah… no.",
       "You really thought that would work?",
       "Close me? In this economy?",
       "I'm built different. Try 'contact' instead."
@@ -504,8 +504,8 @@
     "noArgs": "{command} takes no arguments.",
     "missingName": "Missing theme name.",
     "tooManyArgs": "Too many arguments.",
-    "usageSet": "Usage: theme set <name>",
-    "usagePreview": "Usage: theme preview <name>",
+    "usageSet": "Usage: theme set '<name>'",
+    "usagePreview": "Usage: theme preview '<name>'",
     "unknownSubcommand": "Unknown sub-command: {sub}. Use one of: {commands}.",
     "list": {
       "available": "Available themes ({count}):",
@@ -518,7 +518,7 @@
       "unknown": "Unknown theme: {name}.",
       "runListHint": "Run <link></link> to see available themes.",
       "previewing": "Previewing {label}",
-      "autoReverts": "— auto-reverts in {seconds}s",
+      "autoReverts": "- auto-reverts in {seconds}s",
       "applyHintPrefix": "Use",
       "applyHintSuffix": "to apply permanently."
     },

--- a/messages/es.json
+++ b/messages/es.json
@@ -26,7 +26,7 @@
     "intro": "<tagline>Nómada digital</tagline> · <job>Ingeniero de software</job> · <freelance>Freelance</freelance>",
     "tags": {
       "openSource": "Defensor del open source",
-      "calisthenics": "Devoto de la calistenia",
+      "calisthenics": "Apasionado de la calistenia",
       "stack": "React · Next.js"
     },
     "sections": {
@@ -107,7 +107,7 @@
       "sudo rm -rf / ? Pues… no.",
       "¿De verdad creías que iba a funcionar?",
       "¿Cerrarme? ¿En esta época?",
-      "Estoy hecho diferente. Prueba 'contact' mejor."
+      "Soy de otra pasta. Prueba 'contact' mejor."
     ]
   },
   "Commands": {
@@ -321,8 +321,8 @@
         "fetchEntriesFailed": "No se pudieron recuperar las entradas del libro de visitas.",
         "fetchCountriesFailed": "No se pudieron recuperar los países.",
         "saveFailed": "No se pudo guardar la entrada del libro de visitas.",
-        "rateLimitCheckFailed": "Falló la comprobación del límite de tasa.",
-        "rateLimitExceeded": "Límite de tasa superado. Vuelve a intentarlo más tarde.",
+        "rateLimitCheckFailed": "Falló la comprobación del límite de frecuencia.",
+        "rateLimitExceeded": "Has superado el límite de frecuencia. Vuelve a intentarlo más tarde.",
         "nameTooShort": "El nombre debe tener al menos 2 caracteres.",
         "messageTooShort": "El mensaje debe tener al menos 2 caracteres.",
         "websiteInvalid": "La URL del sitio web no es válida."
@@ -337,7 +337,7 @@
     "openNowPlayingAria": "Abrir canción en reproducción: {name}",
     "openRecentlyPlayedAria": "Abrir canción reciente: {name}",
     "openTopTrackAria": "Abrir canción favorita: {name}",
-    "openTopAlbumAria": "Abrir álbum favorito: {name}",
+    "openTopAlbumAria": "Abrir álbum destacado: {name}",
     "topTracks": {
       "rank": "Posición",
       "track": "Canción",
@@ -504,8 +504,8 @@
     "noArgs": "{command} no acepta argumentos.",
     "missingName": "Falta el nombre del tema.",
     "tooManyArgs": "Demasiados argumentos.",
-    "usageSet": "Uso: theme set <nombre>",
-    "usagePreview": "Uso: theme preview <nombre>",
+    "usageSet": "Uso: theme set '<name>'",
+    "usagePreview": "Uso: theme preview '<name>'",
     "unknownSubcommand": "Subcomando desconocido: {sub}. Usa una de estas opciones: {commands}.",
     "list": {
       "available": "Temas disponibles ({count}):",
@@ -518,7 +518,7 @@
       "unknown": "Tema desconocido: {name}.",
       "runListHint": "Ejecuta <link></link> para ver los temas disponibles.",
       "previewing": "Vista previa de {label}",
-      "autoReverts": "— se revierte automáticamente en {seconds}s",
+      "autoReverts": "- se revierte automáticamente en {seconds}s",
       "applyHintPrefix": "Usa",
       "applyHintSuffix": "para aplicarlo de forma permanente."
     },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,6 +1,6 @@
 {
   "Metadata": {
-    "title": "Alexandre Gossard | Nomade numérique & Ingénieur logiciel",
+    "title": "Alexandre Gossard | Nomade numérique & ingénieur logiciel",
     "description": "Nomade numérique et ingénieur logiciel freelance. Passionné d'open source, je conçois des expériences web performantes avec React et Next.js.",
     "jobTitle": "Ingénieur logiciel",
     "location": "Châlons-en-Champagne, France",
@@ -19,14 +19,14 @@
     ]
   },
   "Footer": {
-    "madeBy": "Conçu avec <heart></heart> par <name></name>"
+    "madeBy": "Fait avec <heart></heart> par <name></name>"
   },
   "Welcome": {
     "greeting": "~ Bienvenue <wave>👋</wave>",
     "intro": "<tagline>Nomade numérique</tagline> · <job>Ingénieur logiciel</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "openSource": "Adepte de l'open source",
-      "calisthenics": "Pratiquant de calisthénie",
+      "openSource": "Passionné d'open source",
+      "calisthenics": "Passionné de calisthénie",
       "stack": "React · Next.js"
     },
     "sections": {
@@ -63,7 +63,7 @@
       "hide": "Masquer la recherche"
     },
     "input": {
-      "placeholder": "saisissez une commande…",
+      "placeholder": "tapez une commande…",
       "submit": "Exécuter la commande"
     },
     "fontSize": {
@@ -107,7 +107,7 @@
       "sudo rm -rf / ? Heu… non.",
       "Tu pensais vraiment que ça allait marcher ?",
       "Me fermer ? Par ces temps qui courent ?",
-      "Je suis bâti différemment. Essaie « contact » à la place."
+      "Je ne suis pas fait comme les autres. Essaie « contact » à la place."
     ]
   },
   "Commands": {
@@ -121,11 +121,11 @@
     },
     "descriptions": {
       "projects": "Ce que j'ai construit, livré ou auquel j'ai contribué",
-      "experiences": "Mes expériences professionnelles et accomplissements",
+      "experiences": "Mon parcours professionnel et mes réalisations",
       "about": "En savoir plus sur mon parcours, mes intérêts et mes objectifs",
       "skills": "Compétences techniques, outils et technologies que j'utilise",
       "education": "Mon parcours académique et mes diplômes",
-      "contact": "Mon adresse e-mail, mes liens sociaux et mes canaux de contact",
+      "contact": "Mon adresse e-mail, mes liens sociaux et mes contacts",
       "guestbook": "Affiche l'aide pour les sous-commandes du livre d'or",
       "cv": "Prévisualiser et télécharger mon CV au format PDF",
       "spotify": "Affiche l'aide pour les sous-commandes Spotify",
@@ -133,7 +133,7 @@
       "help": "Afficher toutes les commandes disponibles avec leurs descriptions",
       "clear": "Effacer toutes les commandes et sorties précédentes",
       "reset": "Réinitialiser le terminal à l'écran d'accueil",
-      "stats": "Afficher mon activité de codage, GitHub et le nombre de visiteurs",
+      "stats": "Afficher l'activité de codage, les métriques GitHub et les visiteurs uniques",
       "repo": "Ouvrir le code source de ce portfolio",
       "echo": "Afficher un message dans le terminal",
       "spotifyNow": "Afficher le morceau en cours d'écoute",
@@ -504,8 +504,8 @@
     "noArgs": "{command} ne prend pas d'argument.",
     "missingName": "Nom du thème manquant.",
     "tooManyArgs": "Trop d'arguments.",
-    "usageSet": "Utilisation : theme set <nom>",
-    "usagePreview": "Utilisation : theme preview <nom>",
+    "usageSet": "Utilisation : theme set '<name>'",
+    "usagePreview": "Utilisation : theme preview '<name>'",
     "unknownSubcommand": "Sous-commande inconnue : {sub}. Utilisez une de ces options : {commands}.",
     "list": {
       "available": "Thèmes disponibles ({count}) :",
@@ -518,7 +518,7 @@
       "unknown": "Thème inconnu : {name}.",
       "runListHint": "Lancez <link></link> pour voir les thèmes disponibles.",
       "previewing": "Prévisualisation de {label}",
-      "autoReverts": "— retour automatique dans {seconds}s",
+      "autoReverts": "- retour automatique dans {seconds}s",
       "applyHintPrefix": "Utilisez",
       "applyHintSuffix": "pour l'appliquer définitivement."
     },
@@ -595,7 +595,7 @@
         "destructive": "Destructif",
         "border": "Bordure",
         "input": "Champ de saisie",
-        "ring": "Anneau",
+        "ring": "Contour de focus",
         "primary": "Primaire",
         "secondary": "Secondaire",
         "tertiary": "Tertiaire",

--- a/messages/he.json
+++ b/messages/he.json
@@ -1,7 +1,4 @@
 {
-  "_meta": {
-    "needsReview": true
-  },
   "Metadata": {
     "title": "אלכסנדר גוסארד | נווד דיגיטלי ומהנדס תוכנה",
     "description": "נווד דיגיטלי ומהנדס תוכנה פרילנס. חובב קוד פתוח, יוצר חוויות ווב מהירות עם React ו-Next.js.",
@@ -356,8 +353,8 @@
     "noArgs": "{command} לא מקבל ארגומנטים.",
     "missingName": "חסר שם ערכת נושא.",
     "tooManyArgs": "יותר מדי ארגומנטים.",
-    "usageSet": "שימוש: theme set <שם>",
-    "usagePreview": "שימוש: theme preview <שם>",
+    "usageSet": "שימוש: theme set '<name>'",
+    "usagePreview": "שימוש: theme preview '<name>'",
     "unknownSubcommand": "פקודת משנה לא ידועה: {sub}. השתמש באחד מ: {commands}.",
     "list": {
       "available": "ערכות נושא זמינות ({count}):",
@@ -375,7 +372,7 @@
       "unknown": "ערכת נושא לא ידועה: {name}.",
       "runListHint": "הריצו <link></link> כדי לראות ערכות זמינות.",
       "previewing": "תצוגה מקדימה של {label}",
-      "autoReverts": "— חוזרת אוטומטית בעוד {seconds} שניות",
+      "autoReverts": "- חוזרת אוטומטית בעוד {seconds} שניות",
       "applyHintPrefix": "השתמשו ב",
       "applyHintSuffix": "כדי להחיל לצמיתות."
     },

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -1,7 +1,4 @@
 {
-  "_meta": {
-    "needsReview": true
-  },
   "Metadata": {
     "title": "अलेक्जेंडर गोसार्ड | डिजिटल खानाबदोश और सॉफ्टवेयर इंजीनियर",
     "description": "डिजिटल खानाबदोश और फ्रीलांस सॉफ्टवेयर इंजीनियर। ओपन सोर्स के शौकीन, React और Next.js के साथ बेहतरीन वेब अनुभव बनाता हूँ।",
@@ -356,8 +353,8 @@
     "noArgs": "{command} तर्क स्वीकार नहीं करता।",
     "missingName": "थीम का नाम गायब है।",
     "tooManyArgs": "बहुत अधिक तर्क।",
-    "usageSet": "उपयोग: theme set <नाम>",
-    "usagePreview": "उपयोग: theme preview <नाम>",
+    "usageSet": "उपयोग: theme set '<name>'",
+    "usagePreview": "उपयोग: theme preview '<name>'",
     "unknownSubcommand": "अज्ञात सब-कमांड: {sub}. इनमें से एक का उपयोग करें: {commands}.",
     "list": {
       "available": "उपलब्ध थीम ({count}):",
@@ -375,7 +372,7 @@
       "unknown": "अज्ञात थीम: {name}.",
       "runListHint": "उपलब्ध थीम देखने के लिए <link></link> चलाएँ.",
       "previewing": "{label} का पूर्वावलोकन",
-      "autoReverts": "— {seconds} सेकंड में स्वतः वापस होगा",
+      "autoReverts": "- {seconds} सेकंड में स्वतः वापस होगा",
       "applyHintPrefix": "स्थायी रूप से लागू करने के लिए",
       "applyHintSuffix": "का उपयोग करें."
     },

--- a/messages/id.json
+++ b/messages/id.json
@@ -1,7 +1,4 @@
 {
-  "_meta": {
-    "needsReview": true
-  },
   "Metadata": {
     "title": "Alexandre Gossard | Pengelana digital & Software Engineer",
     "description": "Pengelana digital dan software engineer freelance. Pegiat open source, saya merancang pengalaman web berperforma tinggi dengan React dan Next.js.",
@@ -356,8 +353,8 @@
     "noArgs": "{command} tidak menerima argumen.",
     "missingName": "Nama tema hilang.",
     "tooManyArgs": "Terlalu banyak argumen.",
-    "usageSet": "Penggunaan: theme set <nama>",
-    "usagePreview": "Penggunaan: theme preview <nama>",
+    "usageSet": "Penggunaan: theme set '<name>'",
+    "usagePreview": "Penggunaan: theme preview '<name>'",
     "unknownSubcommand": "Subperintah tidak dikenal: {sub}. Gunakan salah satu: {commands}.",
     "list": {
       "available": "Tema tersedia ({count}):",
@@ -375,7 +372,7 @@
       "unknown": "Tema tidak dikenal: {name}.",
       "runListHint": "Jalankan <link></link> untuk melihat tema yang tersedia.",
       "previewing": "Pratinjau {label}",
-      "autoReverts": "— kembali otomatis dalam {seconds} detik",
+      "autoReverts": "- kembali otomatis dalam {seconds} detik",
       "applyHintPrefix": "Gunakan",
       "applyHintSuffix": "untuk menerapkan secara permanen."
     },

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,8 +1,8 @@
 {
   "Metadata": {
-    "title": "Alexandre Gossard | Nomade digitale & Software Engineer",
-    "description": "Nomade digitale e software engineer freelance. Appassionato di open source, creo esperienze web performanti con React e Next.js.",
-    "jobTitle": "Software Engineer",
+    "title": "Alexandre Gossard | Nomade digitale & ingegnere software",
+    "description": "Nomade digitale e ingegnere software freelance. Appassionato di open source, creo esperienze web performanti con React e Next.js.",
+    "jobTitle": "Ingegnere software",
     "location": "Châlons-en-Champagne, Francia",
     "ogImageAlt": "Alexandre Gossard",
     "keywords": [
@@ -23,10 +23,10 @@
   },
   "Welcome": {
     "greeting": "~ Benvenuto <wave>👋</wave>",
-    "intro": "<tagline>Nomade digitale</tagline> · <job>Software Engineer</job> · <freelance>Freelance</freelance>",
+    "intro": "<tagline>Nomade digitale</tagline> · <job>Ingegnere software</job> · <freelance>Freelance</freelance>",
     "tags": {
       "openSource": "Sostenitore dell'open source",
-      "calisthenics": "Devoto della calisthenics",
+      "calisthenics": "Appassionato di calistenia",
       "stack": "React · Next.js"
     },
     "sections": {
@@ -107,7 +107,7 @@
       "sudo rm -rf / ? Eh… no.",
       "Pensavi davvero che avrebbe funzionato?",
       "Chiudermi? In questa congiuntura?",
-      "Sono fatto diversamente. Prova «contact»."
+      "Sono fatto a modo mio. Prova «contact»."
     ]
   },
   "Commands": {
@@ -126,9 +126,9 @@
       "skills": "Competenze tecniche, strumenti e tecnologie che uso",
       "education": "Il mio percorso accademico",
       "contact": "Email, social e canali di contatto preferiti",
-      "guestbook": "Mostra l'aiuto per i sotto-comandi del libro degli ospiti",
+      "guestbook": "Mostra l'aiuto per i sottocomandi del libro degli ospiti",
       "cv": "Anteprima e download del mio CV in PDF",
-      "spotify": "Mostra l'aiuto per i sotto-comandi Spotify",
+      "spotify": "Mostra l'aiuto per i sottocomandi Spotify",
       "theme": "Mostra o cambia il tema dell'interfaccia",
       "help": "Mostra tutti i comandi disponibili e le rispettive descrizioni",
       "clear": "Cancella tutti i comandi e gli output precedenti",
@@ -153,7 +153,7 @@
     "help": {
       "available": "Comandi disponibili",
       "tip": "Suggerimento: clicca su un comando o digitalo nel prompt per eseguirlo.",
-      "subCommands": "Sotto-comandi"
+      "subCommands": "Sottocomandi"
     },
     "notFound": {
       "title": "zsh: comando non trovato: {input}",
@@ -504,8 +504,8 @@
     "noArgs": "{command} non accetta argomenti.",
     "missingName": "Manca il nome del tema.",
     "tooManyArgs": "Troppi argomenti.",
-    "usageSet": "Uso: theme set <nome>",
-    "usagePreview": "Uso: theme preview <nome>",
+    "usageSet": "Uso: theme set '<name>'",
+    "usagePreview": "Uso: theme preview '<name>'",
     "unknownSubcommand": "Sotto-comando sconosciuto: {sub}. Usa una di queste opzioni: {commands}.",
     "list": {
       "available": "Temi disponibili ({count}):",
@@ -518,7 +518,7 @@
       "unknown": "Tema sconosciuto: {name}.",
       "runListHint": "Esegui <link></link> per vedere i temi disponibili.",
       "previewing": "Anteprima di {label}",
-      "autoReverts": "— ripristino automatico tra {seconds}s",
+      "autoReverts": "- ripristino automatico tra {seconds}s",
       "applyHintPrefix": "Usa",
       "applyHintSuffix": "per applicarlo definitivamente."
     },
@@ -530,7 +530,7 @@
     "validate": {
       "header": "Audit di contrasto WCAG AA per {name}:",
       "passCount": "{count} OK",
-      "failCount": "{count} fallimento",
+      "failCount": "{count} KO",
       "totalChecked": "({count} coppie controllate)",
       "skippedWarning": "⚠️ Alcuni colori saltati (formato non supportato)",
       "allPass": "Tutte le coppie soddisfano i requisiti WCAG AA.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,7 +1,4 @@
 {
-  "_meta": {
-    "needsReview": true
-  },
   "Metadata": {
     "title": "Alexandre Gossard | デジタルノマド & ソフトウェアエンジニア",
     "description": "デジタルノマド兼フリーランスのソフトウェアエンジニア。オープンソース愛好家として、React と Next.js でパフォーマンスの高いウェブ体験を作っています。",
@@ -78,7 +75,7 @@
     },
     "settings": {
       "title": "ターミナル設定",
-      "resetAllTitle": "すべての設定をリセット(サイズも含む)",
+      "resetAllTitle": "すべての設定をリセット（サイズも含む）",
       "resetAllLabel": "すべてリセット",
       "closeTitle": "設定を閉じる",
       "closeLabel": "設定を閉じる",
@@ -88,7 +85,7 @@
       "scrollbackOption": "{count, plural, =0 {コマンドなし} other {# コマンド}}",
       "darkSuffix": "ダーク",
       "lightSuffix": "ライト",
-      "themeOption": "{label}({mode})",
+      "themeOption": "{label}（{mode}）",
       "languageLabel": "言語"
     },
     "shortcutsHeading": "キーボードショートカット",
@@ -103,14 +100,14 @@
       "decreaseFontSize": "フォントサイズを小さく"
     },
     "closeMessages": [
-      "残念!私を閉じることはできません。",
-      "どこにも行きません。代わりに 'help' を試してみてください!",
-      "いいえ。このターミナルは閉じるボタンに不信感を抱いています。",
-      "エラー 418:私はティーポットであり、閉じられる窓ではありません。",
-      "sudo rm -rf / ?うーん…やめておきます。",
-      "本当にそれでうまくいくと思いましたか?",
-      "私を閉じる?この経済状況で?",
-      "私は違うんです。代わりに 'contact' を試してみてください。"
+      "惜しい！でも、私を閉じることはできません。",
+      "どこにも行きません。代わりに 'help' を試してみてください！",
+      "いいえ。このターミナルは閉じるボタンを信用していません。",
+      "エラー 418：私はティーポットであって、閉じられるウィンドウではありません。",
+      "sudo rm -rf /？うーん…やめておきます。",
+      "本当にそれでうまくいくと思いましたか？",
+      "私を閉じる？このご時世に？",
+      "私はひと味違います。代わりに 'contact' を試してください。"
     ]
   },
   "Commands": {
@@ -504,8 +501,8 @@
     "noArgs": "{command} は引数を受け付けません。",
     "missingName": "テーマ名がありません。",
     "tooManyArgs": "引数が多すぎます。",
-    "usageSet": "使い方: theme set <名前>",
-    "usagePreview": "使い方: theme preview <名前>",
+    "usageSet": "使い方: theme set '<name>'",
+    "usagePreview": "使い方: theme preview '<name>'",
     "unknownSubcommand": "不明なサブコマンド: {sub}。次のいずれかを使用してください: {commands}。",
     "list": {
       "available": "利用可能なテーマ({count}):",
@@ -518,14 +515,14 @@
       "unknown": "不明なテーマ: {name}。",
       "runListHint": "<link></link> を実行して利用可能なテーマを確認してください。",
       "previewing": "{label} をプレビュー中",
-      "autoReverts": "— {seconds} 秒後に自動で元に戻ります",
+      "autoReverts": "- {seconds} 秒後に自動で元に戻ります",
       "applyHintPrefix": "永続的に適用するには",
       "applyHintSuffix": "を使用してください。"
     },
     "set": {
       "unknownAvailable": "不明なテーマ: {name}。利用可能なテーマ:",
       "updated": "テーマが {label} に更新されました。",
-      "active": "アクティブなテーマ: {label}({mode})"
+      "active": "アクティブなテーマ: {label}（{mode}）"
     },
     "validate": {
       "header": "{name} の WCAG AA コントラスト監査:",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,7 +1,4 @@
 {
-  "_meta": {
-    "needsReview": true
-  },
   "Metadata": {
     "title": "Alexandre Gossard | 디지털 노마드 & 소프트웨어 엔지니어",
     "description": "디지털 노마드이자 프리랜서 소프트웨어 엔지니어. 오픈소스 애호가로서 React와 Next.js로 고성능 웹 경험을 만들고 있습니다.",
@@ -22,7 +19,7 @@
     ]
   },
   "Footer": {
-    "madeBy": "<name></name>가 <heart></heart>으로 만들었습니다"
+    "madeBy": "<name></name>가 <heart></heart>을 담아 만들었습니다"
   },
   "Welcome": {
     "greeting": "~ 환영합니다 <wave>👋</wave>",
@@ -105,12 +102,12 @@
     "closeMessages": [
       "좋은 시도! 하지만 저를 닫을 수는 없어요.",
       "어디 가지 않아요. 'help'를 시도해 보세요!",
-      "안 됩니다. 이 터미널은 닫기 버튼에 대한 신뢰 문제가 있어요.",
+      "안 됩니다. 이 터미널은 닫기 버튼을 믿지 않아요.",
       "오류 418: 저는 찻주전자입니다. 닫을 수 있는 창이 아니에요.",
       "sudo rm -rf / ? 음… 안 돼요.",
       "정말 그게 통할 거라고 생각했나요?",
       "저를 닫는다고요? 이 시국에?",
-      "저는 다르게 만들어졌어요. 'contact'를 시도해 보세요."
+      "저는 좀 다르게 만들어졌거든요. 'contact'를 시도해 보세요."
     ]
   },
   "Commands": {
@@ -356,8 +353,8 @@
     "noArgs": "{command}은(는) 인수를 받지 않습니다.",
     "missingName": "테마 이름이 누락되었습니다.",
     "tooManyArgs": "인수가 너무 많습니다.",
-    "usageSet": "사용법: theme set <이름>",
-    "usagePreview": "사용법: theme preview <이름>",
+    "usageSet": "사용법: theme set '<name>'",
+    "usagePreview": "사용법: theme preview '<name>'",
     "unknownSubcommand": "알 수 없는 하위 명령: {sub}. 다음 중 하나를 사용하세요: {commands}.",
     "list": {
       "available": "사용 가능한 테마 ({count}):",
@@ -375,7 +372,7 @@
       "unknown": "알 수 없는 테마: {name}.",
       "runListHint": "사용 가능한 테마를 보려면 <link></link>를 실행하세요.",
       "previewing": "{label} 미리보기",
-      "autoReverts": "— {seconds}초 후 자동 복원",
+      "autoReverts": "- {seconds}초 후 자동 복원",
       "applyHintPrefix": "영구 적용하려면",
       "applyHintSuffix": "사용하세요."
     },

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -1,20 +1,20 @@
 {
   "Metadata": {
-    "title": "Alexandre Gossard | Digital Nomad & Software Engineer",
-    "description": "Digital nomad en freelance software engineer. Open source-enthousiasteling, ik bouw performante webervaringen met React en Next.js.",
-    "jobTitle": "Software Engineer",
+    "title": "Alexandre Gossard | Digitale nomade & software-engineer",
+    "description": "Digitale nomade en freelance software-engineer. Als opensource-enthousiast bouw ik snelle webervaringen met React en Next.js.",
+    "jobTitle": "Software-engineer",
     "location": "Châlons-en-Champagne, Frankrijk",
     "ogImageAlt": "Alexandre Gossard",
     "keywords": [
       "Alexandre Gossard",
-      "Frontend ontwikkelaar",
-      "Digital Nomad",
+      "Frontendontwikkelaar",
+      "Digitale nomade",
       "Open source",
       "Moderne technologieën",
       "hakkaofdev",
       "kabila.app",
       "Kabila",
-      "Software Engineer",
+      "Software-engineer",
       "Freelance"
     ]
   },
@@ -23,9 +23,9 @@
   },
   "Welcome": {
     "greeting": "~ Welkom <wave>👋</wave>",
-    "intro": "<tagline>Digital Nomad</tagline> · <job>Software Engineer</job> · <freelance>Freelance</freelance>",
+    "intro": "<tagline>Digitale nomade</tagline> · <job>Software-engineer</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "openSource": "Open source-pleitbezorger",
+      "openSource": "Voorvechter van open source",
       "calisthenics": "Calisthenics-liefhebber",
       "stack": "React · Next.js"
     },
@@ -38,7 +38,7 @@
     }
   },
   "Terminal": {
-    "noMatch": "Geen commando komt overeen met „{query}\".",
+    "noMatch": "Geen commando komt overeen met “{query}”.",
     "header": {
       "resetTitle": "Terminal resetten (Ctrl+R)",
       "resetLabel": "Terminal resetten",
@@ -50,7 +50,7 @@
       "minimize": "Terminal minimaliseren",
       "restoreMinimize": "Terminal herstellen",
       "expand": "Terminal vergroten",
-      "restoreExpand": "Grootte van terminal herstellen"
+      "restoreExpand": "Terminalgrootte herstellen"
     },
     "tabs": {
       "rename": "{name} hernoemen",
@@ -101,13 +101,13 @@
     },
     "closeMessages": [
       "Mooie poging! Je kunt me niet sluiten.",
-      "Ik ga nergens heen. Probeer „help\"!",
+      "Ik ga nergens heen. Probeer 'help'!",
       "Nee. Deze terminal heeft vertrouwensproblemen met sluitknoppen.",
       "Fout 418: ik ben een theepot, geen sluitbaar venster.",
       "sudo rm -rf / ? Eh… nee.",
       "Dacht je echt dat dat zou werken?",
       "Mij sluiten? In deze tijd?",
-      "Ik ben anders gebouwd. Probeer „contact\"."
+      "Ik ben gewoon anders gebouwd. Probeer 'contact'."
     ]
   },
   "Commands": {
@@ -263,9 +263,9 @@
   },
   "OpenGraph": {
     "tags": {
-      "digitalNomad": "Digital Nomad",
+      "digitalNomad": "Digitale nomade",
       "nextjs": "Next.js",
-      "uiEngineering": "UI Engineering",
+      "uiEngineering": "UI-engineering",
       "openSource": "Open source"
     },
     "footer": "Portfolio"
@@ -353,8 +353,8 @@
     "noArgs": "{command} accepteert geen argumenten.",
     "missingName": "Themanaam ontbreekt.",
     "tooManyArgs": "Te veel argumenten.",
-    "usageSet": "Gebruik: theme set <naam>",
-    "usagePreview": "Gebruik: theme preview <naam>",
+    "usageSet": "Gebruik: theme set '<name>'",
+    "usagePreview": "Gebruik: theme preview '<name>'",
     "unknownSubcommand": "Onbekend subcommando: {sub}. Gebruik een van: {commands}.",
     "list": {
       "available": "Beschikbare thema's ({count}):",
@@ -365,14 +365,14 @@
     },
     "set": {
       "unknownAvailable": "Onbekend thema: {name}. Beschikbare thema's:",
-      "updated": "Thema gewijzigd naar {label}.",
+      "updated": "Thema ingesteld op {label}.",
       "active": "Actief thema: {label} ({mode})"
     },
     "preview": {
       "unknown": "Onbekend thema: {name}.",
       "runListHint": "Voer <link></link> uit om beschikbare thema's te zien.",
       "previewing": "Voorbeeld van {label}",
-      "autoReverts": "— terug in {seconds} s",
+      "autoReverts": "- terug in {seconds} s",
       "applyHintPrefix": "Gebruik",
       "applyHintSuffix": "om permanent toe te passen."
     },
@@ -419,7 +419,7 @@
       "resetColorsAria": "Kleuren herstellen naar standaard",
       "jsonHint": "Ondersteunt OKLCH (aanbevolen), hex, rgb, hsl. Contrastvalidatie werkt voor alle formaten.",
       "jsonRequired": "Vereiste sleutels: name, label, isDark, colors ({count} tokens)",
-      "previewToggle": "Live voorbeeld",
+      "previewToggle": "Livevoorbeeld",
       "successMessagePrefix": "Aangepast thema",
       "successMessageSuffix": "aangemaakt en toegepast.",
       "successHint": "Wordt bewaard in localStorage van de browser.",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -38,7 +38,7 @@
     }
   },
   "Terminal": {
-    "noMatch": "Żadna komenda nie pasuje do „{query}\".",
+    "noMatch": "Żadna komenda nie pasuje do „{query}“.",
     "header": {
       "resetTitle": "Resetuj terminal (Ctrl+R)",
       "resetLabel": "Resetuj terminal",
@@ -101,13 +101,13 @@
     },
     "closeMessages": [
       "Niezła próba! Nie możesz mnie zamknąć.",
-      "Nigdzie się nie wybieram. Spróbuj „help\"!",
+      "Nigdzie się nie wybieram. Spróbuj „help“!",
       "Nie. Ten terminal ma problemy z zaufaniem do przycisków zamknięcia.",
       "Błąd 418: jestem czajnikiem, nie zamykanym oknem.",
       "sudo rm -rf / ? Eee… nie.",
       "Naprawdę myślałeś, że to zadziała?",
       "Zamknąć mnie? W tych czasach?",
-      "Jestem inny. Spróbuj „contact\"."
+      "Jestem po prostu z innej gliny. Spróbuj „contact“."
     ]
   },
   "Commands": {
@@ -353,8 +353,8 @@
     "noArgs": "{command} nie przyjmuje argumentów.",
     "missingName": "Brak nazwy motywu.",
     "tooManyArgs": "Zbyt wiele argumentów.",
-    "usageSet": "Użycie: theme set <nazwa>",
-    "usagePreview": "Użycie: theme preview <nazwa>",
+    "usageSet": "Użycie: theme set '<name>'",
+    "usagePreview": "Użycie: theme preview '<name>'",
     "unknownSubcommand": "Nieznana podkomenda: {sub}. Użyj jednej z: {commands}.",
     "list": {
       "available": "Dostępne motywy ({count}):",
@@ -372,7 +372,7 @@
       "unknown": "Nieznany motyw: {name}.",
       "runListHint": "Uruchom <link></link>, aby zobaczyć dostępne motywy.",
       "previewing": "Podgląd {label}",
-      "autoReverts": "— powrót za {seconds} s",
+      "autoReverts": "- powrót za {seconds} s",
       "applyHintPrefix": "Użyj",
       "applyHintSuffix": "aby zastosować na stałe."
     },

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -26,7 +26,7 @@
     "intro": "<tagline>Nómada digital</tagline> · <job>Engenheiro de software</job> · <freelance>Freelancer</freelance>",
     "tags": {
       "openSource": "Defensor do open source",
-      "calisthenics": "Devoto de calistenia",
+      "calisthenics": "Apaixonado por calistenia",
       "stack": "React · Next.js"
     },
     "sections": {
@@ -107,7 +107,7 @@
       "sudo rm -rf / ? Pois… não.",
       "Achavas mesmo que ia funcionar?",
       "Fechar-me? Nestes tempos?",
-      "Sou diferente. Experimenta «contact»."
+      "Sou de outra fibra. Experimenta «contact»."
     ]
   },
   "Commands": {
@@ -504,8 +504,8 @@
     "noArgs": "{command} não aceita argumentos.",
     "missingName": "Falta o nome do tema.",
     "tooManyArgs": "Demasiados argumentos.",
-    "usageSet": "Utilização: theme set <nome>",
-    "usagePreview": "Utilização: theme preview <nome>",
+    "usageSet": "Utilização: theme set '<name>'",
+    "usagePreview": "Utilização: theme preview '<name>'",
     "unknownSubcommand": "Subcomando desconhecido: {sub}. Usa uma destas opções: {commands}.",
     "list": {
       "available": "Temas disponíveis ({count}):",
@@ -518,7 +518,7 @@
       "unknown": "Tema desconhecido: {name}.",
       "runListHint": "Executa <link></link> para ver os temas disponíveis.",
       "previewing": "Pré-visualização de {label}",
-      "autoReverts": "— reverte automaticamente em {seconds}s",
+      "autoReverts": "- reverte automaticamente em {seconds}s",
       "applyHintPrefix": "Usa",
       "applyHintSuffix": "para aplicar permanentemente."
     },

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -1,7 +1,4 @@
 {
-  "_meta": {
-    "needsReview": true
-  },
   "Metadata": {
     "title": "Alexandre Gossard | Nomad digital și inginer software",
     "description": "Nomad digital și inginer software freelance. Pasionat de open source, creez experiențe web performante cu React și Next.js.",
@@ -41,7 +38,7 @@
     }
   },
   "Terminal": {
-    "noMatch": "Nicio comandă nu corespunde cu „{query}\".",
+    "noMatch": "Nicio comandă nu corespunde cu „{query}“.",
     "header": {
       "resetTitle": "Resetează terminalul (Ctrl+R)",
       "resetLabel": "Resetează terminalul",
@@ -104,13 +101,13 @@
     },
     "closeMessages": [
       "Bună încercare! Nu mă poți închide.",
-      "Nu plec nicăieri. Încearcă „help\"!",
+      "Nu plec nicăieri. Încearcă „help“!",
       "Nu. Acest terminal are probleme de încredere cu butoanele de închidere.",
       "Eroare 418: sunt un ceainic, nu o fereastră închidere.",
       "sudo rm -rf / ? Hmm… nu.",
       "Chiar credeai că va funcționa?",
       "Să mă închizi? În aceste vremuri?",
-      "Sunt construit altfel. Încearcă „contact\"."
+      "Sunt făcut altfel. Încearcă „contact“."
     ]
   },
   "Commands": {
@@ -356,8 +353,8 @@
     "noArgs": "{command} nu acceptă argumente.",
     "missingName": "Lipsește numele temei.",
     "tooManyArgs": "Prea multe argumente.",
-    "usageSet": "Utilizare: theme set <nume>",
-    "usagePreview": "Utilizare: theme preview <nume>",
+    "usageSet": "Utilizare: theme set '<name>'",
+    "usagePreview": "Utilizare: theme preview '<name>'",
     "unknownSubcommand": "Subcomandă necunoscută: {sub}. Folosește una din: {commands}.",
     "list": {
       "available": "Teme disponibile ({count}):",
@@ -375,7 +372,7 @@
       "unknown": "Temă necunoscută: {name}.",
       "runListHint": "Rulează <link></link> pentru a vedea temele disponibile.",
       "previewing": "Previzualizare {label}",
-      "autoReverts": "— revine în {seconds} s",
+      "autoReverts": "- revine în {seconds} s",
       "applyHintPrefix": "Folosește",
       "applyHintSuffix": "pentru a aplica permanent."
     },

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -353,8 +353,8 @@
     "noArgs": "{command} не принимает аргументов.",
     "missingName": "Не указано имя темы.",
     "tooManyArgs": "Слишком много аргументов.",
-    "usageSet": "Использование: theme set <имя>",
-    "usagePreview": "Использование: theme preview <имя>",
+    "usageSet": "Использование: theme set '<name>'",
+    "usagePreview": "Использование: theme preview '<name>'",
     "unknownSubcommand": "Неизвестная подкоманда: {sub}. Используйте: {commands}.",
     "list": {
       "available": "Доступные темы ({count}):",
@@ -372,7 +372,7 @@
       "unknown": "Неизвестная тема: {name}.",
       "runListHint": "Запустите <link></link>, чтобы увидеть доступные темы.",
       "previewing": "Предпросмотр {label}",
-      "autoReverts": "— возврат через {seconds} с",
+      "autoReverts": "- возврат через {seconds} с",
       "applyHintPrefix": "Используйте",
       "applyHintSuffix": "чтобы применить навсегда."
     },

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -353,8 +353,8 @@
     "noArgs": "{command} argüman almıyor.",
     "missingName": "Tema adı eksik.",
     "tooManyArgs": "Çok fazla argüman.",
-    "usageSet": "Kullanım: theme set <ad>",
-    "usagePreview": "Kullanım: theme preview <ad>",
+    "usageSet": "Kullanım: theme set '<name>'",
+    "usagePreview": "Kullanım: theme preview '<name>'",
     "unknownSubcommand": "Bilinmeyen alt komut: {sub}. Şunlardan birini kullanın: {commands}.",
     "list": {
       "available": "Mevcut temalar ({count}):",
@@ -372,7 +372,7 @@
       "unknown": "Bilinmeyen tema: {name}.",
       "runListHint": "Mevcut temaları görmek için <link></link> komutunu çalıştırın.",
       "previewing": "Önizleme: {label}",
-      "autoReverts": "— {seconds} sn sonra geri döner",
+      "autoReverts": "- {seconds} sn sonra geri döner",
       "applyHintPrefix": "Kalıcı uygulamak için",
       "applyHintSuffix": "kullanın."
     },

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -353,8 +353,8 @@
     "noArgs": "{command} не приймає аргументів.",
     "missingName": "Не вказано ім'я теми.",
     "tooManyArgs": "Забагато аргументів.",
-    "usageSet": "Використання: theme set <ім'я>",
-    "usagePreview": "Використання: theme preview <ім'я>",
+    "usageSet": "Використання: theme set '<name>'",
+    "usagePreview": "Використання: theme preview '<name>'",
     "unknownSubcommand": "Невідома підкоманда: {sub}. Використовуйте: {commands}.",
     "list": {
       "available": "Доступні теми ({count}):",
@@ -372,7 +372,7 @@
       "unknown": "Невідома тема: {name}.",
       "runListHint": "Запустіть <link></link>, щоб побачити доступні теми.",
       "previewing": "Перегляд {label}",
-      "autoReverts": "— повернення через {seconds} с",
+      "autoReverts": "- повернення через {seconds} с",
       "applyHintPrefix": "Використайте",
       "applyHintSuffix": "щоб застосувати назавжди."
     },

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -1,7 +1,4 @@
 {
-  "_meta": {
-    "needsReview": true
-  },
   "Metadata": {
     "title": "Alexandre Gossard | Du mục số & Kỹ sư phần mềm",
     "description": "Du mục số và kỹ sư phần mềm freelance. Đam mê mã nguồn mở, tôi tạo trải nghiệm web hiệu năng cao với React và Next.js.",
@@ -356,8 +353,8 @@
     "noArgs": "{command} không nhận đối số.",
     "missingName": "Thiếu tên chủ đề.",
     "tooManyArgs": "Quá nhiều đối số.",
-    "usageSet": "Cách dùng: theme set <tên>",
-    "usagePreview": "Cách dùng: theme preview <tên>",
+    "usageSet": "Cách dùng: theme set '<name>'",
+    "usagePreview": "Cách dùng: theme preview '<name>'",
     "unknownSubcommand": "Lệnh con không xác định: {sub}. Sử dụng một trong: {commands}.",
     "list": {
       "available": "Chủ đề khả dụng ({count}):",
@@ -375,7 +372,7 @@
       "unknown": "Chủ đề không xác định: {name}.",
       "runListHint": "Chạy <link></link> để xem các chủ đề khả dụng.",
       "previewing": "Đang xem trước {label}",
-      "autoReverts": "— tự khôi phục sau {seconds} giây",
+      "autoReverts": "- tự khôi phục sau {seconds} giây",
       "applyHintPrefix": "Dùng",
       "applyHintSuffix": "để áp dụng vĩnh viễn."
     },

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1,12 +1,9 @@
 {
-  "_meta": {
-    "needsReview": true
-  },
   "Metadata": {
     "title": "Alexandre Gossard | 数字游民 & 软件工程师",
-    "description": "数字游民和自由职业软件工程师。开源爱好者,使用 React 和 Next.js 打造高性能的网络体验。",
+    "description": "数字游民和自由职业软件工程师。作为开源爱好者，我使用 React 和 Next.js 打造高性能 Web 体验。",
     "jobTitle": "软件工程师",
-    "location": "法国 沙隆昂尚帕涅",
+    "location": "法国沙隆昂香槟",
     "ogImageAlt": "Alexandre Gossard",
     "keywords": [
       "Alexandre Gossard",
@@ -35,13 +32,13 @@
     "sections": {
       "start": "开始",
       "work": "工作",
-      "profile": "资料",
+      "profile": "个人资料",
       "extras": "扩展",
       "utils": "工具"
     }
   },
   "Terminal": {
-    "noMatch": "没有命令匹配 \"{query}\"。",
+    "noMatch": "没有命令匹配“{query}”。",
     "header": {
       "resetTitle": "重置终端 (Ctrl+R)",
       "resetLabel": "重置终端",
@@ -78,7 +75,7 @@
     },
     "settings": {
       "title": "终端设置",
-      "resetAllTitle": "重置所有设置(包括尺寸)",
+      "resetAllTitle": "重置所有设置（包括尺寸）",
       "resetAllLabel": "全部重置",
       "closeTitle": "关闭设置",
       "closeLabel": "关闭设置",
@@ -88,7 +85,7 @@
       "scrollbackOption": "{count, plural, =0 {无命令} other {# 条命令}}",
       "darkSuffix": "深色",
       "lightSuffix": "浅色",
-      "themeOption": "{label}({mode})",
+      "themeOption": "{label}（{mode}）",
       "languageLabel": "语言"
     },
     "shortcutsHeading": "键盘快捷键",
@@ -103,20 +100,20 @@
       "decreaseFontSize": "减小字体"
     },
     "closeMessages": [
-      "好尝试!但你关不掉我。",
-      "我哪儿也不去。试试 'help' 吧!",
+      "不错的尝试！但你关不掉我。",
+      "我哪儿也不去。试试 'help' 吧！",
       "不行。这个终端对关闭按钮有信任问题。",
-      "错误 418:我是个茶壶,不是可关闭的窗口。",
-      "sudo rm -rf / ?嗯…还是算了。",
-      "你真的觉得这能行得通?",
-      "关掉我?在这个时代?",
-      "我与众不同。试试 'contact' 吧。"
+      "错误 418：我是个茶壶，不是可以关闭的窗口。",
+      "sudo rm -rf /？嗯…还是算了。",
+      "你真的觉得这能行得通？",
+      "关掉我？都这个年代了？",
+      "我可不一样。试试 'contact' 吧。"
     ]
   },
   "Commands": {
     "groups": {
       "Work": "工作",
-      "Profile": "资料",
+      "Profile": "个人资料",
       "Guestbook": "留言板",
       "Spotify": "Spotify",
       "Theme": "主题",
@@ -128,7 +125,7 @@
       "about": "了解我的背景、兴趣和职业目标",
       "skills": "查看我使用的技术栈、工具和技能",
       "education": "我的学历和教育背景",
-      "contact": "邮箱、社交媒体和联系方式",
+      "contact": "邮箱、社交链接和首选联系方式",
       "guestbook": "显示留言板子命令的帮助",
       "cv": "预览并下载我的 PDF 简历",
       "spotify": "显示 Spotify 子命令的帮助",
@@ -136,7 +133,7 @@
       "help": "显示所有可用命令及其说明",
       "clear": "清除所有之前的命令和输出",
       "reset": "重置终端到欢迎屏幕",
-      "stats": "显示编程活动、GitHub 数据和访客数",
+      "stats": "显示编程活动、GitHub 指标和独立访客数",
       "repo": "打开此作品集的源代码仓库",
       "echo": "在终端中打印一条消息",
       "spotifyNow": "显示当前正在播放的歌曲",
@@ -175,13 +172,13 @@
       "lastName": "姓",
       "age": "年龄",
       "yearsOld": "{years} 岁",
-      "location": "位置",
+      "location": "所在地",
       "email": "邮箱",
       "languages": "语言",
       "hobbies": "爱好"
     },
     "contact": {
-      "intro": "对于工作机会、自由职业请求或技术合作,我更喜欢通过邮件联系。",
+      "intro": "如有工作机会、自由职业委托或技术合作，我更喜欢通过邮件联系。",
       "primaryEmail": "主邮箱:",
       "location": "位置:",
       "socialProfiles": "社交资料:"
@@ -207,7 +204,7 @@
       "copiedNotice": "已复制!",
       "copyFailedAria": "复制失败",
       "copyFailedNotice": "重试",
-      "fallback": "此作品集的源代码可在此查看:"
+      "fallback": "此作品集的源代码可在此查看："
     },
     "cv": {
       "openPreview": "打开 PDF 预览",
@@ -216,7 +213,7 @@
       "endpointsAnd": "和"
     },
     "projects": {
-      "openLabel": "打开项目: {name}"
+      "openLabel": "打开项目：{name}"
     }
   },
   "Suggestions": {
@@ -504,8 +501,8 @@
     "noArgs": "{command} 不接受参数。",
     "missingName": "缺少主题名称。",
     "tooManyArgs": "参数过多。",
-    "usageSet": "用法: theme set <名称>",
-    "usagePreview": "用法: theme preview <名称>",
+    "usageSet": "用法: theme set '<name>'",
+    "usagePreview": "用法: theme preview '<name>'",
     "unknownSubcommand": "未知子命令: {sub}。请使用其中之一: {commands}。",
     "list": {
       "available": "可用主题({count}):",
@@ -518,14 +515,14 @@
       "unknown": "未知主题: {name}。",
       "runListHint": "运行 <link></link> 查看可用主题。",
       "previewing": "预览 {label}",
-      "autoReverts": "— {seconds} 秒后自动还原",
+      "autoReverts": "- {seconds} 秒后自动还原",
       "applyHintPrefix": "使用",
       "applyHintSuffix": "永久应用。"
     },
     "set": {
       "unknownAvailable": "未知主题: {name}。可用主题:",
       "updated": "主题已更新为 {label}。",
-      "active": "当前主题: {label}({mode})"
+      "active": "当前主题: {label}（{mode}）"
     },
     "validate": {
       "header": "{name} 的 WCAG AA 对比度审计:",


### PR DESCRIPTION
## Summary

- Replace `...` with `…` and `—` with `-` across user-facing strings (terminal placeholders, close-button quips, theme auto-revert hint, guestbook header).
- Quote `<name>` in the `theme set` / `theme preview` usage hints so the angle-bracket placeholder doesn't collide with shell redirection when copied.
- Refresh assorted welcome / footer / command-description copy, mostly in the French translation.
- No code-path changes — i18n strings + one TSX literal.

## Test plan

- [x] `pnpm typecheck` passes
- [x] All 22 `messages/*.json` files parse
- [x] Spot-check the rendered terminal in EN and FR: `Filter command history…`, `type a command…`, the close-button quip, the theme `auto-reverts in {seconds}s` hint
- [x] Guestbook header renders with `-` between the label and the entry count