### PR TITLE
feat(skills): add soft skills, state/data, and Figma

### DIFF
--- a/lib/constants/skills.constants.ts
+++ b/lib/constants/skills.constants.ts
@@ -5,6 +5,17 @@ export type SkillGroup = {
 };
 
 export const SKILLS: ReadonlyArray<SkillGroup> = [
+  {
+    slug: "softSkills",
+    values: [
+      "Technical Leadership",
+      "Mentoring",
+      "Ownership",
+      "Project Planning",
+      "Decision-Making",
+      "Critical Thinking",
+    ],
+  },
   { slug: "languages", values: ["Javascript", "Typescript", "Python"] },
   {
     slug: "frameworks",
@@ -18,7 +29,8 @@ export const SKILLS: ReadonlyArray<SkillGroup> = [
       "Django",
     ],
   },
-  { slug: "uiStyling", values: ["Tailwind", "shadcn/ui", "Motion"] },
+  { slug: "stateData", values: ["TanStack Query", "Zustand", "Redux"] },
+  { slug: "uiStyling", values: ["Tailwind", "shadcn/ui", "Motion", "Figma"] },
   { slug: "tooling", values: ["Biome", "Bun"] },
   { slug: "databases", values: ["PostgreSQL", "Supabase", "MongoDB", "Redis"] },
   { slug: "cloud", values: ["Vercel", "AWS"] },

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -590,7 +590,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "الأتمتة",
-      "ai": "الذكاء الاصطناعي"
+      "ai": "الذكاء الاصطناعي",
+      "stateData": "الحالة والبيانات",
+      "softSkills": "المهارات الشخصية"
     },
     "spokenLanguages": {
       "fr": "الفرنسية",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -590,7 +590,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Automatizace",
-      "ai": "AI"
+      "ai": "AI",
+      "stateData": "Stav a Data",
+      "softSkills": "Měkké dovednosti"
     },
     "spokenLanguages": {
       "fr": "Francouzština",

--- a/messages/de.json
+++ b/messages/de.json
@@ -480,7 +480,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Automatisierung",
-      "ai": "KI"
+      "ai": "KI",
+      "stateData": "Status & Daten",
+      "softSkills": "Soft Skills"
     },
     "spokenLanguages": {
       "fr": "Französisch",

--- a/messages/el.json
+++ b/messages/el.json
@@ -590,7 +590,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Αυτοματισμός",
-      "ai": "AI"
+      "ai": "AI",
+      "stateData": "Κατάσταση & Δεδομένα",
+      "softSkills": "Διαπροσωπικές Δεξιότητες"
     },
     "spokenLanguages": {
       "fr": "Γαλλικά",

--- a/messages/en.json
+++ b/messages/en.json
@@ -521,7 +521,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Automation",
-      "ai": "AI"
+      "ai": "AI",
+      "stateData": "State & Data",
+      "softSkills": "Soft Skills"
     },
     "spokenLanguages": {
       "fr": "French",

--- a/messages/es.json
+++ b/messages/es.json
@@ -480,7 +480,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Automatización",
-      "ai": "IA"
+      "ai": "IA",
+      "stateData": "Estado y Datos",
+      "softSkills": "Habilidades blandas"
     },
     "spokenLanguages": {
       "fr": "Francés",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -480,7 +480,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Automatisation",
-      "ai": "IA"
+      "ai": "IA",
+      "stateData": "État & Données",
+      "softSkills": "Soft skills"
     },
     "spokenLanguages": {
       "fr": "Français",

--- a/messages/he.json
+++ b/messages/he.json
@@ -587,7 +587,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "אוטומציה",
-      "ai": "AI"
+      "ai": "AI",
+      "stateData": "מצב ונתונים",
+      "softSkills": "כישורים רכים"
     },
     "spokenLanguages": {
       "fr": "צרפתית",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -590,7 +590,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "स्वचालन",
-      "ai": "AI"
+      "ai": "AI",
+      "stateData": "स्टेट और डेटा",
+      "softSkills": "सॉफ्ट स्किल्स"
     },
     "spokenLanguages": {
       "fr": "फ्रेंच",

--- a/messages/id.json
+++ b/messages/id.json
@@ -590,7 +590,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Otomasi",
-      "ai": "AI"
+      "ai": "AI",
+      "stateData": "Status & Data",
+      "softSkills": "Soft Skills"
     },
     "spokenLanguages": {
       "fr": "Bahasa Prancis",

--- a/messages/it.json
+++ b/messages/it.json
@@ -480,7 +480,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Automazione",
-      "ai": "IA"
+      "ai": "IA",
+      "stateData": "Stato e Dati",
+      "softSkills": "Soft skill"
     },
     "spokenLanguages": {
       "fr": "Francese",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -477,7 +477,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "自動化",
-      "ai": "AI"
+      "ai": "AI",
+      "stateData": "状態とデータ",
+      "softSkills": "ソフトスキル"
     },
     "spokenLanguages": {
       "fr": "フランス語",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -587,7 +587,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "자동화",
-      "ai": "AI"
+      "ai": "AI",
+      "stateData": "상태 및 데이터",
+      "softSkills": "소프트 스킬"
     },
     "spokenLanguages": {
       "fr": "프랑스어",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -590,7 +590,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Automatisering",
-      "ai": "AI"
+      "ai": "AI",
+      "stateData": "Status & Data",
+      "softSkills": "Soft skills"
     },
     "spokenLanguages": {
       "fr": "Frans",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -590,7 +590,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Automatyzacja",
-      "ai": "AI"
+      "ai": "AI",
+      "stateData": "Stan i Dane",
+      "softSkills": "Umiejętności miękkie"
     },
     "spokenLanguages": {
       "fr": "Francuski",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -480,7 +480,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Automação",
-      "ai": "IA"
+      "ai": "IA",
+      "stateData": "Estado e Dados",
+      "softSkills": "Soft skills"
     },
     "spokenLanguages": {
       "fr": "Francês",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -590,7 +590,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Automatizare",
-      "ai": "IA"
+      "ai": "IA",
+      "stateData": "Stare și Date",
+      "softSkills": "Soft skills"
     },
     "spokenLanguages": {
       "fr": "Franceză",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -590,7 +590,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Автоматизация",
-      "ai": "ИИ"
+      "ai": "ИИ",
+      "stateData": "Состояние и данные",
+      "softSkills": "Гибкие навыки"
     },
     "spokenLanguages": {
       "fr": "Французский",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -590,7 +590,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Otomasyon",
-      "ai": "Yapay Zeka"
+      "ai": "Yapay Zeka",
+      "stateData": "Durum ve Veri",
+      "softSkills": "Kişisel Beceriler"
     },
     "spokenLanguages": {
       "fr": "Fransızca",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -590,7 +590,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Автоматизація",
-      "ai": "ШІ"
+      "ai": "ШІ",
+      "stateData": "Стан і дані",
+      "softSkills": "Гнучкі навички"
     },
     "spokenLanguages": {
       "fr": "Французька",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -590,7 +590,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "Tự động hóa",
-      "ai": "AI"
+      "ai": "AI",
+      "stateData": "Trạng thái & Dữ liệu",
+      "softSkills": "Kỹ năng mềm"
     },
     "spokenLanguages": {
       "fr": "Tiếng Pháp",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -477,7 +477,9 @@
       "orm": "ORM",
       "devops": "DevOps",
       "automation": "自动化",
-      "ai": "AI"
+      "ai": "AI",
+      "stateData": "状态与数据",
+      "softSkills": "软技能"
     },
     "spokenLanguages": {
       "fr": "法语",


### PR DESCRIPTION
## Summary
- Introduce a `softSkills` group at the top of the skills inventory to surface lead-engineer signals alongside technical groups.
- Add a `stateData` group covering data-layer and state libraries.
- Include Figma under `uiStyling`, and translate the two new groups across all 22 supported locales.

## Changes

### Features
- `softSkills` group: Technical Leadership, Mentoring, Ownership, Project Planning, Decision-Making, Critical Thinking.
- `stateData` group: TanStack Query, Zustand, Redux.
- `uiStyling`: Figma added.

### Configuration
- 22 locale message files updated with `CV.skillGroups.softSkills` and `CV.skillGroups.stateData` translations (ar, cs, de, el, en, es, fr, he, hi, id, it, ja, ko, nl, pl, pt, ro, ru, tr, uk, vi, zh).

## Testing
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm format:check` passes
- [x] `vice audit` 100/100
- [x] Verify new groups render in the terminal via `skills` command in dev
- [x] Verify CV PDF includes the new groups
- [x] Spot-check translations in 2-3 locales

## Breaking Changes
None

## Commits
$(git log origin/develop..HEAD --oneline)