### PR TITLE
Adopt logical Tailwind v4 utilities

### DIFF
--- a/components/commands/renders/guestbook/read/GuestbookEntryRow.tsx
+++ b/components/commands/renders/guestbook/read/GuestbookEntryRow.tsx
@@ -48,7 +48,7 @@ export function GuestbookEntryRow({
         isLast ? "pb-0" : "pb-3",
       )}
     >
-      <div className="absolute -start-[5px] top-[5px] size-2 rounded-full bg-quinary" />
+      <div className="absolute inset-s-[-5px] top-[5px] size-2 rounded-full bg-quinary" />
 
       <div className="flex items-baseline gap-2">
         <span className="shrink-0 font-mono text-muted-foreground/50 text-xs">

--- a/components/commands/renders/guestbook/read/ReadSkeleton.tsx
+++ b/components/commands/renders/guestbook/read/ReadSkeleton.tsx
@@ -8,7 +8,7 @@ export function ReadSkeleton() {
           key={i}
           className="relative animate-pulse border-muted/40 border-s-2 ps-4 pb-3"
         >
-          <div className="absolute -start-[5px] top-[5px] size-2 rounded-full bg-muted" />
+          <div className="absolute inset-s-[-5px] top-[5px] size-2 rounded-full bg-muted" />
           <div className="flex items-center gap-2">
             <div className="h-2.5 w-6 rounded bg-muted" />
             <div className="h-3 w-24 rounded bg-muted" />

--- a/components/ui/Popover.tsx
+++ b/components/ui/Popover.tsx
@@ -29,7 +29,7 @@ const PopoverContent = ({
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[60] w-72 rounded-md bg-muted/60 p-4 text-foreground shadow-md outline-none ring-1 ring-border/50 ring-inset data-[state=closed]:animate-out data-[state=open]:animate-in dark:bg-overlay-subtle dark:ring-overlay-medium",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-60 w-72 rounded-md bg-muted/60 p-4 text-foreground shadow-md outline-none ring-1 ring-border/50 ring-inset data-[state=closed]:animate-out data-[state=open]:animate-in dark:bg-overlay-subtle dark:ring-overlay-medium",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Replace directional and arbitrary Tailwind classes with their logical / scale equivalents in three UI components.

## Changes

### Style
- `-start-[5px]` → `inset-s-[-5px]` on the guestbook entry/skeleton timeline dots.
- `z-[1]`/`z-[60]` → `z-1`/`z-60` for the popover and related elements.

No behavioral change — visual output is identical, the classes just align with the Tailwind v4 setup.

## Testing
- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run format:check` — clean

## Breaking Changes
None

## Commits
8f3bda0 style(ui): migrate to logical inset and z utilities
