### PR TITLE
Simplify country code guards with optional chaining

### DIFF
--- a/lib/services/guestbook-client.ts
+++ b/lib/services/guestbook-client.ts
@@ -53,7 +53,7 @@ async function fetchCountries(): Promise<string[]> {
 // ─── Formatting ──────────────────────────────────────────────────────────────
 
 function countryToFlag(code: string | null) {
-  if (!code || code.length !== 2) return null;
+  if (code?.length !== 2) return null;
   const upper = code.toUpperCase();
   return String.fromCodePoint(
     ...[...upper].map((c) => 0x1f1e6 + c.charCodeAt(0) - 65),

--- a/lib/utils/country.utils.ts
+++ b/lib/utils/country.utils.ts
@@ -3,7 +3,7 @@
  * Returns a placeholder for unknown / invalid codes.
  */
 export function countryCodeToFlag(code: string | null | undefined): string {
-  if (!code || code.length !== 2) return "🏳";
+  if (code?.length !== 2) return "🏳";
 
   const upper = code.toUpperCase();
   const a = upper.charCodeAt(0);


### PR DESCRIPTION
## Summary
- Simplify the country-code-to-flag guards by collapsing the explicit null check and length check into a single optional-chaining expression.

## Changes

### Refactors
- `countryToFlag` (guestbook client) and `countryCodeToFlag` (country utils): `!code || code.length !== 2` → `code?.length !== 2`.

Behavior is unchanged — a null/undefined or non-two-char code still returns the placeholder / null.

## Testing
- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run format:check` — clean

## Breaking Changes
None

## Commits
11a0440 refactor(utils): use optional chaining for country code guards
