### PR TITLE
perf: use default image quality for avatar

### DIFF
--- a/components/WelcomeHero.tsx
+++ b/components/WelcomeHero.tsx
@@ -29,7 +29,6 @@ function WelcomeHero({
           src="/avatar.jpg"
           alt="Alexandre Gossard"
           className="aspect-square shrink-0 rounded-lg object-cover object-top shadow-sm ring-1 ring-border/60 dark:ring-overlay-medium"
-          quality={100}
           width={88}
           height={88}
           sizes="176px"


### PR DESCRIPTION
## Summary
- Remove the `quality={100}` override on the hero avatar so it uses next/image's default quality.

## Changes
### Performance
- The avatar renders at 88px (176px `sizes`); default quality is visually indistinguishable there and produces a smaller optimized image.

## Testing
- `bun run typecheck` — passes
- `bun run lint` — passes
- `bun run format:check` — passes

## Breaking Changes
None

## Commits
- perf(hero): use default image quality for avatar
