### PR TITLE
chore: add GraphQL to skills list

### DIFF
--- a/lib/constants/skills.constants.ts
+++ b/lib/constants/skills.constants.ts
@@ -30,7 +30,10 @@ export const SKILLS: ReadonlyArray<SkillGroup> = [
       "Django",
     ],
   },
-  { slug: "stateData", values: ["TanStack Query", "Zustand", "Redux", "Zod"] },
+  {
+    slug: "stateData",
+    values: ["TanStack Query", "GraphQL", "Zustand", "Redux", "Zod"],
+  },
   { slug: "uiStyling", values: ["Tailwind", "shadcn/ui", "Motion", "Figma"] },
   { slug: "tooling", values: ["Biome", "Bun"] },
   { slug: "testing", values: ["Vitest", "Playwright"] },


### PR DESCRIPTION
## Summary
- Add GraphQL to the state & data group shown by the skills command.

## Changes
### Configuration
- `lib/constants/skills.constants.ts`: insert "GraphQL" into the `stateData` skill group.

## Testing
- `bun run typecheck` — passes
- `bun run lint` — passes
- `bun run format:check` — passes

## Breaking Changes
None

## Commits
- chore(skills): add GraphQL to state & data skills
