### PR TITLE
chore(content): update freelance day rate

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -24,7 +24,7 @@
     "greeting": "~ مرحبًا <wave>👋</wave>",
     "intro": "<tagline>رحالة رقمي</tagline> · <job>مهندس برمجيات</job> · <freelance>مستقل</freelance>",
     "tags": {
-      "rate": "600 يورو/يوم",
+      "rate": "600 دولار/يوم",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -24,7 +24,7 @@
     "greeting": "~ Vítej <wave>👋</wave>",
     "intro": "<tagline>Digitální nomád</tagline> · <job>Softwarový inženýr</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "rate": "600 €/den",
+      "rate": "600 $/den",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/de.json
+++ b/messages/de.json
@@ -24,7 +24,7 @@
     "greeting": "~ Willkommen <wave>👋</wave>",
     "intro": "<tagline>Digitaler Nomade</tagline> · <job>Software-Ingenieur</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "rate": "600 €/Tag",
+      "rate": "600 $/Tag",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/el.json
+++ b/messages/el.json
@@ -24,7 +24,7 @@
     "greeting": "~ Καλώς ήρθες <wave>👋</wave>",
     "intro": "<tagline>Ψηφιακός νομάδας</tagline> · <job>Μηχανικός λογισμικού</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "rate": "600 €/ημέρα",
+      "rate": "600 $/ημέρα",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -24,7 +24,7 @@
     "greeting": "~ Welcome <wave>👋</wave>",
     "intro": "<tagline>Digital Nomad</tagline> · <job>Software Engineer</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "rate": "€600/day",
+      "rate": "$600/day",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/es.json
+++ b/messages/es.json
@@ -24,7 +24,7 @@
     "greeting": "~ Bienvenido <wave>👋</wave>",
     "intro": "<tagline>Nómada digital</tagline> · <job>Ingeniero de software</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "rate": "600 €/día",
+      "rate": "600 $/día",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -24,7 +24,7 @@
     "greeting": "~ Bienvenue <wave>👋</wave>",
     "intro": "<tagline>Nomade numérique</tagline> · <job>Ingénieur logiciel</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "rate": "600€ en TJM",
+      "rate": "550€ en TJM",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/he.json
+++ b/messages/he.json
@@ -24,7 +24,7 @@
     "greeting": "~ ברוך הבא <wave>👋</wave>",
     "intro": "<tagline>נווד דיגיטלי</tagline> · <job>מהנדס תוכנה</job> · <freelance>פרילנס</freelance>",
     "tags": {
-      "rate": "600 €/יום",
+      "rate": "600 $/יום",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -24,7 +24,7 @@
     "greeting": "~ स्वागत है <wave>👋</wave>",
     "intro": "<tagline>डिजिटल खानाबदोश</tagline> · <job>सॉफ्टवेयर इंजीनियर</job> · <freelance>फ्रीलांस</freelance>",
     "tags": {
-      "rate": "€600/दिन",
+      "rate": "$600/दिन",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/id.json
+++ b/messages/id.json
@@ -24,7 +24,7 @@
     "greeting": "~ Selamat datang <wave>👋</wave>",
     "intro": "<tagline>Pengelana digital</tagline> · <job>Software Engineer</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "rate": "€600/hari",
+      "rate": "$600/hari",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/it.json
+++ b/messages/it.json
@@ -24,7 +24,7 @@
     "greeting": "~ Benvenuto <wave>👋</wave>",
     "intro": "<tagline>Nomade digitale</tagline> · <job>Ingegnere software</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "rate": "600 €/giorno",
+      "rate": "600 $/giorno",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -24,7 +24,7 @@
     "greeting": "~ ようこそ <wave>👋</wave>",
     "intro": "<tagline>デジタルノマド</tagline> · <job>ソフトウェアエンジニア</job> · <freelance>フリーランス</freelance>",
     "tags": {
-      "rate": "600€/日",
+      "rate": "600$/日",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -24,7 +24,7 @@
     "greeting": "~ 환영합니다 <wave>👋</wave>",
     "intro": "<tagline>디지털 노마드</tagline> · <job>소프트웨어 엔지니어</job> · <freelance>프리랜서</freelance>",
     "tags": {
-      "rate": "600€/일",
+      "rate": "600$/일",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -24,7 +24,7 @@
     "greeting": "~ Welkom <wave>👋</wave>",
     "intro": "<tagline>Digitale nomade</tagline> · <job>Software-engineer</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "rate": "€600/dag",
+      "rate": "$600/dag",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -24,7 +24,7 @@
     "greeting": "~ Witaj <wave>👋</wave>",
     "intro": "<tagline>Cyfrowy nomada</tagline> · <job>Inżynier oprogramowania</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "rate": "600 €/dzień",
+      "rate": "600 $/dzień",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -24,7 +24,7 @@
     "greeting": "~ Bem-vindo <wave>👋</wave>",
     "intro": "<tagline>Nómada digital</tagline> · <job>Engenheiro de software</job> · <freelance>Freelancer</freelance>",
     "tags": {
-      "rate": "600 €/dia",
+      "rate": "600 $/dia",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -24,7 +24,7 @@
     "greeting": "~ Bun venit <wave>👋</wave>",
     "intro": "<tagline>Nomad digital</tagline> · <job>Inginer software</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "rate": "600 €/zi",
+      "rate": "600 $/zi",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -24,7 +24,7 @@
     "greeting": "~ Добро пожаловать <wave>👋</wave>",
     "intro": "<tagline>Цифровой кочевник</tagline> · <job>Инженер-программист</job> · <freelance>Фриланс</freelance>",
     "tags": {
-      "rate": "600 €/день",
+      "rate": "600 $/день",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -24,7 +24,7 @@
     "greeting": "~ Hoş geldin <wave>👋</wave>",
     "intro": "<tagline>Dijital göçebe</tagline> · <job>Yazılım mühendisi</job> · <freelance>Serbest çalışan</freelance>",
     "tags": {
-      "rate": "600 €/gün",
+      "rate": "600 $/gün",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -24,7 +24,7 @@
     "greeting": "~ Ласкаво просимо <wave>👋</wave>",
     "intro": "<tagline>Цифровий номад</tagline> · <job>Інженер-програміст</job> · <freelance>Фріланс</freelance>",
     "tags": {
-      "rate": "600 €/день",
+      "rate": "600 $/день",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -24,7 +24,7 @@
     "greeting": "~ Chào mừng <wave>👋</wave>",
     "intro": "<tagline>Du mục số</tagline> · <job>Kỹ sư phần mềm</job> · <freelance>Freelance</freelance>",
     "tags": {
-      "rate": "600 €/ngày",
+      "rate": "600 $/ngày",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -24,7 +24,7 @@
     "greeting": "~ 欢迎 <wave>👋</wave>",
     "intro": "<tagline>数字游民</tagline> · <job>软件工程师</job> · <freelance>自由职业</freelance>",
     "tags": {
-      "rate": "600€/天",
+      "rate": "600$/天",
       "web": "React/Next.js",
       "mobile": "Expo/React Native"
     },


### PR DESCRIPTION
## Summary
- Update the displayed freelance day rate in the hero tags across all 22 locales

## Changes
### Configuration
- en → `$600/day` (was `€600/day`)
- fr → `550€ en TJM` (was `600€ en TJM`)
- equivalent rate refresh applied to the remaining locales

## Testing
- `bun run typecheck` — passes
- `bun run lint` — passes
- `bun run format:check` — passes

## Breaking Changes
None

## Commits
7cb352a chore(content): update freelance day rate across locales
