### PR TITLE
chore(skills): add Jest to testing skills

### DIFF
--- a/lib/constants/skills.constants.ts
+++ b/lib/constants/skills.constants.ts
@@ -36,7 +36,7 @@ export const SKILLS: ReadonlyArray<SkillGroup> = [
   },
   { slug: "uiStyling", values: ["Tailwind", "shadcn/ui", "Motion", "Figma"] },
   { slug: "tooling", values: ["Biome", "Bun"] },
-  { slug: "testing", values: ["Vitest", "Playwright"] },
+  { slug: "testing", values: ["Vitest", "Playwright", "Jest"] },
   { slug: "databases", values: ["PostgreSQL", "Supabase", "MongoDB", "Redis"] },
   { slug: "cloud", values: ["Vercel", "AWS"] },
   { slug: "vcs", values: ["Git", "Gitlab"] },


### PR DESCRIPTION
## Summary
- Add **Jest** to the testing skill group alongside Vitest and Playwright

## Changes
### Configuration
- `skills.constants.ts`: append `Jest` to the `testing` group values

## Testing
- `bun run typecheck` — passes
- `bun run lint` — passes
- `bun run format:check` — passes

## Breaking Changes
None

## Commits
35cc159 chore(skills): add Jest to testing skills
