### PR TITLE
feat(seo): web app manifest and enriched site metadata

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -19,7 +19,9 @@ import { getDirection, type Locale, routing } from "@/i18n/routing";
 import {
   GITHUB_URL,
   getYearsOfExperience,
+  LANGUAGES,
   SITE,
+  SKILLS,
   SOCIALS,
 } from "@/lib/constants";
 import { getSiteUrl } from "@/lib/site-url";
@@ -75,9 +77,14 @@ export async function generateMetadata({
   const canonicalPath = buildCanonicalPath(locale);
   const ogImagePath = buildOpenGraphImagePath(locale);
 
-  const languageAlternates = Object.fromEntries(
-    routing.locales.map((l) => [l, buildCanonicalPath(l)]),
-  );
+  const languageAlternates: Record<string, string> = {
+    ...Object.fromEntries(
+      routing.locales.map((l) => [l, buildCanonicalPath(l)]),
+    ),
+    // x-default tells search engines which URL to serve for unmatched
+    // languages — required for a correct multi-locale hreflang cluster.
+    "x-default": buildCanonicalPath(routing.defaultLocale),
+  };
 
   return {
     title,
@@ -92,7 +99,7 @@ export async function generateMetadata({
       description,
       url: new URL(canonicalPath, siteUrl).toString(),
       type: "website",
-      siteName: title,
+      siteName: SITE.name,
       locale,
       images: [
         {
@@ -119,6 +126,11 @@ export async function generateMetadata({
       },
     ],
     metadataBase: new URL(siteUrl),
+    icons: {
+      icon: "/favicon.ico",
+      shortcut: "/favicon.ico",
+      apple: "/logo.png",
+    },
     robots: {
       index: true,
       follow: true,
@@ -133,6 +145,10 @@ export async function generateMetadata({
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#030405" },
+  ],
 };
 
 export function generateStaticParams() {
@@ -158,19 +174,35 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
     getTranslations({ locale, namespace: "Metadata" }),
   ]);
 
+  const [givenName, ...familyParts] = SITE.name.split(" ");
   const personJsonLd = {
     "@context": "https://schema.org",
     "@type": "Person",
+    "@id": `${siteUrl}/#person`,
     name: SITE.name,
+    givenName,
+    familyName: familyParts.join(" "),
     url: siteUrl,
     image: new URL("/avatar.jpg", siteUrl).toString(),
     jobTitle: t("jobTitle"),
     description: t("description", { years: getYearsOfExperience() }),
+    email: `mailto:${SITE.email}`,
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: "Châlons-en-Champagne",
+      addressCountry: "FR",
+    },
     worksFor: {
       "@type": "Organization",
       name: SITE.employer.name,
       url: SITE.employer.url,
     },
+    knowsAbout: SKILLS.flatMap((group) => group.values),
+    knowsLanguage: LANGUAGES.map((language) => language.code),
+    alumniOf: [
+      { "@type": "CollegeOrUniversity", name: "IUT de Châlons-en-Champagne" },
+      { "@type": "HighSchool", name: "Lycée Jean Talon" },
+    ],
     sameAs: SOCIALS.map((social) => social.url),
   };
 

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from "next";
+import { SITE } from "@/lib/constants";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: SITE.name,
+    short_name: "A. Gossard",
+    description: SITE.description,
+    start_url: "/",
+    display: "standalone",
+    background_color: "#030405",
+    theme_color: "#030405",
+    icons: [
+      {
+        src: "/logo.png",
+        sizes: "192x192",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/logo.png",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "any",
+      },
+    ],
+  };
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -9,8 +9,12 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
+        // API routes return JSON/PDF, not indexable pages — keep them out of
+        // the crawl budget.
+        disallow: "/api/",
       },
     ],
     sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -10,9 +10,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       ? siteUrl
       : new URL(`/${locale}`, siteUrl).toString();
 
-  const languages = Object.fromEntries(
-    routing.locales.map((locale) => [locale, buildLocaleUrl(locale)]),
-  );
+  const languages: Record<string, string> = {
+    ...Object.fromEntries(
+      routing.locales.map((locale) => [locale, buildLocaleUrl(locale)]),
+    ),
+    "x-default": buildLocaleUrl(routing.defaultLocale),
+  };
 
   return [
     {


### PR DESCRIPTION
## Summary

- Add a PWA web app manifest (`app/manifest.ts`).
- Enrich site metadata: theme-color viewport, icon set, and an expanded Person JSON-LD.
- Improve crawl/indexing hints in robots and the sitemap.

## Changes

### Features
- `app/manifest.ts`: standalone PWA manifest with name, description, theme/background colors, and icons.

### SEO / metadata
- `layout.tsx`: theme-color viewport, favicon/apple icons, `x-default` hreflang, and a richer Person JSON-LD (`@id`, given/family name, email, address, `knowsAbout`, `knowsLanguage`, `alumniOf`).
- `robots.ts`: disallow `/api/` and set the canonical `host`.
- `sitemap.ts`: add `x-default` hreflang alternate.

## Testing

- `bun run typecheck` / `lint` / `format:check` — pass
- `bun run build` — succeeds (`/manifest.webmanifest`, `/robots.txt`, `/sitemap.xml` generated)

## Breaking Changes

None

## Commits

fc7a728 feat(seo): add web app manifest and enrich site metadata
