### PR TITLE
ci(release): use built-in GITHUB_TOKEN for release-please auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,10 @@ jobs:
         id: release
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # Built-in, per-run token — nothing stored, nothing to expire or leak.
+          # Requires the top-level `permissions:` block above plus the repo's
+          # "Allow GitHub Actions to create and approve pull requests" setting.
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary
- Switches the release-please step from the `RELEASE_PLEASE_TOKEN` PAT to the built-in `GITHUB_TOKEN`.
- Fixes the failing Release workflow (run failed with `release-please failed: Bad credentials` after PR #110 merged — the PAT was expired/revoked, so no `chore: release 1.15.0` PR was ever opened).

## Why GITHUB_TOKEN
- Minted fresh per run and destroyed at the end — nothing stored, nothing to expire, rotate, or leak. Ends the recurring PAT-breakage.
- Already supported by this repo: the workflow declares `permissions: contents: write` + `pull-requests: write`, and the repo allows Actions to create PRs.

## Trade-off (acceptable)
- Actions-created PRs don't trigger other workflows, so the release PR won't re-run `ci.yml` on its own. That's fine here: no branch protection requires checks, and the full Quality Gate already runs on every push to `main`.

## Rollout
After this merges to `develop`, promote `develop → main`. That push re-runs the Release workflow with the fixed auth, which opens the pending `chore: release 1.15.0` PR.