### PR TITLE
Add Kabila Wallet Native project URL

### DIFF
--- a/lib/constants/projects.constants.ts
+++ b/lib/constants/projects.constants.ts
@@ -23,6 +23,7 @@ export const PROJECTS: ReadonlyArray<ProjectEntry> = [
   },
   {
     slug: "kabilaWalletNative",
+    url: "https://wallet.kabila.app",
     imageUrl: "/projects/kabila-wallet-native.png",
     imagePosition: "object-bottom",
     tags: ["Expo", "React Native", "Typescript", "Blockchain", "Tailwind"],


### PR DESCRIPTION
## Summary
- Add the app URL for the **Kabila Wallet Native** project so it renders a clickable link in the projects section and CV PDF.

## Testing
- `typecheck` ✓ · `lint` ✓

## Breaking Changes
None

## Commits
3535c7e feat(projects): add Kabila Wallet Native app link
