### PR TITLE
feat(window): collapse the window into a footer dock

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { hasLocale } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
 import MainScreen from "@/components/MainScreen";
+import { WindowStage } from "@/components/WindowStage";
 import { routing } from "@/i18n/routing";
 
 type Props = {
@@ -15,7 +16,7 @@ export default async function Home({ params }: Props) {
   setRequestLocale(locale);
 
   return (
-    <main className="container mx-auto flex flex-1 flex-col items-center justify-center gap-8 overflow-hidden px-4 py-6">
+    <WindowStage>
       <Image
         src="/logo.png"
         alt="Alexandre Gossard Logo"
@@ -26,6 +27,6 @@ export default async function Home({ params }: Props) {
         priority
       />
       <MainScreen />
-    </main>
+    </WindowStage>
   );
 }

--- a/components/DockItem.tsx
+++ b/components/DockItem.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { AnimatePresence, m } from "motion/react";
+import Image from "next/image";
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useRef } from "react";
+import { DURATION, EASE_OUT } from "@/lib/animation/motion";
+import { useWindowStore } from "@/stores/window.store";
+
+const TILE_SIZE = 32;
+const SLOT_WIDTH = TILE_SIZE + 12 + 1 + 12;
+
+export function DockItem() {
+  const t = useTranslations("Terminal");
+  const isMinimized = useWindowStore((state) => state.isMinimized);
+  const restore = useWindowStore((state) => state.restore);
+  const setDockAnchor = useWindowStore((state) => state.setDockAnchor);
+  const slotRef = useRef<HTMLDivElement>(null);
+
+  const measure = useCallback(() => {
+    const slot = slotRef.current;
+    if (!slot || useWindowStore.getState().isMinimized) return;
+    const rect = slot.getBoundingClientRect();
+
+    setDockAnchor({
+      x: rect.left - SLOT_WIDTH / 2 + TILE_SIZE / 2,
+      y: rect.bottom - TILE_SIZE / 2,
+    });
+  }, [setDockAnchor]);
+
+  useEffect(() => {
+    measure();
+    window.addEventListener("resize", measure);
+    return () => {
+      window.removeEventListener("resize", measure);
+      setDockAnchor(null);
+    };
+  }, [measure, setDockAnchor]);
+
+  return (
+    <m.div
+      ref={slotRef}
+      initial={false}
+      animate={{ width: isMinimized ? SLOT_WIDTH : 0 }}
+      transition={{ duration: DURATION.base, ease: EASE_OUT }}
+      onAnimationComplete={measure}
+      className="relative -mr-3 h-4.5 shrink-0"
+    >
+      <AnimatePresence>
+        {isMinimized ? (
+          <m.div
+            initial={{ opacity: 0, scale: 0.4, y: 10 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.4, y: 10 }}
+            transition={{ duration: DURATION.base, ease: EASE_OUT }}
+            className="absolute bottom-0 left-0 flex items-end gap-3"
+          >
+            <button
+              type="button"
+              onClick={restore}
+              aria-label={t("trafficLights.restoreMinimize")}
+              className="group relative flex h-8 w-8 cursor-pointer items-center justify-center"
+            >
+              <Image
+                src="/logo.png"
+                alt=""
+                width={TILE_SIZE}
+                height={TILE_SIZE}
+                sizes="64px"
+                className="h-8 w-8 rounded-xl bg-background/70 shadow-sm ring-1 ring-border backdrop-blur-xs transition-transform duration-200 ease-out group-hover:-translate-y-1 group-hover:scale-110 group-active:scale-95 dark:ring-overlay-medium"
+              />
+              <span className="absolute -bottom-2 left-1/2 flex h-1 w-1 -translate-x-1/2">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
+                <span className="relative inline-flex h-1 w-1 rounded-full bg-primary" />
+              </span>
+            </button>
+            <span
+              aria-hidden
+              className="h-5 w-px rounded-full bg-border dark:bg-overlay-medium"
+            />
+          </m.div>
+        ) : null}
+      </AnimatePresence>
+    </m.div>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,6 +1,7 @@
 import { Heart } from "lucide-react";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
+import { DockItem } from "@/components/DockItem";
 import { GITHUB_URL, SITE, SOCIALS } from "@/lib/constants";
 
 async function Footer() {
@@ -9,6 +10,7 @@ async function Footer() {
   return (
     <div className="flex flex-col items-center justify-center gap-3 pt-6 pb-4">
       <div className="flex items-center gap-3">
+        <DockItem />
         {SOCIALS.map((social) => (
           <Link
             key={social.name}

--- a/components/WindowStage.tsx
+++ b/components/WindowStage.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { m } from "motion/react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { DURATION, EASE_OUT } from "@/lib/animation/motion";
+import { cn } from "@/lib/utils";
+import { useWindowStore } from "@/stores/window.store";
+
+const MINIMIZED_SCALE = 0.05;
+
+type Flight = { x: number; y: number };
+
+interface WindowStageProps {
+  children: React.ReactNode;
+}
+
+export function WindowStage({ children }: WindowStageProps) {
+  const isMinimized = useWindowStore((state) => state.isMinimized);
+  const stageRef = useRef<HTMLElement>(null);
+  const wasMinimized = useRef(false);
+  const [flight, setFlight] = useState<Flight>({ x: 0, y: 0 });
+  const [isFlying, setIsFlying] = useState(false);
+
+  useLayoutEffect(() => {
+    if (isMinimized === wasMinimized.current) return;
+    wasMinimized.current = isMinimized;
+    setIsFlying(true);
+    if (!isMinimized) return;
+
+    const stage = stageRef.current;
+    if (!stage) return;
+    const rect = stage.getBoundingClientRect();
+    const originX = rect.left + rect.width / 2;
+    const originY = rect.top + rect.height / 2;
+    const dock = useWindowStore.getState().dockAnchor ?? {
+      x: originX,
+      y: window.innerHeight,
+    };
+    setFlight({ x: dock.x - originX, y: dock.y - originY });
+  }, [isMinimized]);
+
+  const handleAnimationComplete = useCallback(() => setIsFlying(false), []);
+
+  return (
+    <m.main
+      ref={stageRef}
+      initial={false}
+      animate={isMinimized ? "minimized" : "open"}
+      variants={{
+        open: { opacity: 1, scale: 1, x: 0, y: 0 },
+        minimized: {
+          opacity: 0,
+          scale: MINIMIZED_SCALE,
+          x: flight.x,
+          y: flight.y,
+        },
+      }}
+      transition={{ duration: DURATION.slow, ease: EASE_OUT }}
+      onAnimationComplete={handleAnimationComplete}
+      aria-hidden={isMinimized}
+      inert={isMinimized}
+      className={cn(
+        "container mx-auto flex flex-1 flex-col items-center justify-center gap-8 px-4 py-6",
+        isMinimized || isFlying ? "overflow-visible" : "overflow-hidden",
+        isMinimized && !isFlying && "invisible",
+      )}
+    >
+      {children}
+    </m.main>
+  );
+}

--- a/components/terminal/Terminal.tsx
+++ b/components/terminal/Terminal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTerminalResize } from "@/hooks/useTerminalResize";
 import { useTerminalTabs } from "@/hooks/useTerminalTabs";
 import { cn } from "@/lib/utils";
@@ -79,6 +79,8 @@ export const Terminal = ({ children, className }: TerminalProps) => {
     setTerminalLayout,
   });
 
+  const openSettings = useCallback(() => setIsSettingsOpen(true), []);
+
   useEffect(() => {
     if (!isSearchOpen) return;
     searchInputRef.current?.focus();
@@ -91,19 +93,14 @@ export const Terminal = ({ children, className }: TerminalProps) => {
       className={cn(
         "terminal-shell terminal-shadow terminal-resize relative z-0 flex h-full w-full flex-col overflow-hidden rounded-xl border border-border/60 bg-background/45 backdrop-blur-[2px] dark:border-overlay-medium dark:bg-background/70",
         !isMaximized && terminalWidth === null && "max-w-2xl",
-        !isMinimized &&
-          !isMaximized &&
+        !isMaximized &&
           terminalHeight === null &&
           "max-h-[calc(100dvh-120px)] md:max-h-[min(calc(100dvh-120px),450px)]",
-        isMinimized && "max-h-11",
         className,
       )}
       style={resize.containerStyle}
     >
-      <TerminalHeader
-        onResetTerminal={reset}
-        onOpenSettings={() => setIsSettingsOpen(true)}
-      />
+      <TerminalHeader onResetTerminal={reset} onOpenSettings={openSettings} />
 
       <TerminalTabs
         sessionTabs={sessionTabs}
@@ -130,7 +127,6 @@ export const Terminal = ({ children, className }: TerminalProps) => {
       ) : null}
 
       <TerminalBody
-        isMinimized={isMinimized}
         outputViewportRef={tabs.outputViewportRef}
         onOutputScroll={tabs.handleOutputScroll}
         spotifySlot={<SpotifyPlayer />}

--- a/components/terminal/TerminalBody.tsx
+++ b/components/terminal/TerminalBody.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import type { RefObject } from "react";
-import { cn } from "@/lib/utils";
 import { TerminalInput } from "./TerminalInput";
 
 interface TerminalBodyProps {
   children: React.ReactNode;
-  isMinimized: boolean;
   outputViewportRef: RefObject<HTMLPreElement | null>;
   onOutputScroll: () => void;
   spotifySlot: React.ReactNode;
@@ -14,20 +12,12 @@ interface TerminalBodyProps {
 
 function TerminalBody({
   children,
-  isMinimized,
   outputViewportRef,
   onOutputScroll,
   spotifySlot,
 }: TerminalBodyProps) {
   return (
-    <div
-      className={cn(
-        "terminal-zoom-target flex min-h-0 min-w-0 flex-1 flex-col",
-        isMinimized
-          ? "pointer-events-none opacity-0 transition-opacity duration-200 ease-out"
-          : "opacity-100 transition-opacity delay-150 duration-300 ease-in",
-      )}
-    >
+    <div className="terminal-zoom-target flex min-h-0 min-w-0 flex-1 flex-col">
       <pre
         ref={outputViewportRef}
         onScroll={onOutputScroll}

--- a/hooks/useTerminalState.ts
+++ b/hooks/useTerminalState.ts
@@ -17,12 +17,21 @@ import {
 } from "@/lib/utils/terminal.utils";
 import { useTerminalPreferencesStore } from "@/stores/terminal-preferences.store";
 import { useTerminalSessionsStore } from "@/stores/terminal-sessions.store";
+import { useWindowStore } from "@/stores/window.store";
 
 export function useTerminalState() {
   const t = useTranslations("Terminal");
   const { addCommand, commands } = useCommands();
-  const [isMinimized, setIsMinimized] = useState(false);
-  const [isMaximized, setIsMaximized] = useState(false);
+  const { isMinimized, isMaximized, restore, handleMinimize, handleMaximize } =
+    useWindowStore(
+      useShallow((state) => ({
+        isMinimized: state.isMinimized,
+        isMaximized: state.isMaximized,
+        restore: state.restore,
+        handleMinimize: state.toggleMinimize,
+        handleMaximize: state.toggleMaximize,
+      })),
+    );
   const {
     fontScale,
     setFontScale,
@@ -63,25 +72,12 @@ export function useTerminalState() {
   );
 
   const handleClose = useCallback(() => {
-    if (isMinimized) setIsMinimized(false);
+    if (isMinimized) restore();
     const closeMessages = t.raw("closeMessages") as string[];
     const message =
       closeMessages[Math.floor(Math.random() * closeMessages.length)];
     addCommand(`echo "${message}"`);
-  }, [addCommand, isMinimized, t]);
-
-  const handleMinimize = useCallback(() => {
-    setIsMinimized((value) => {
-      const next = !value;
-      if (next) setIsMaximized(false);
-      return next;
-    });
-  }, []);
-
-  const handleMaximize = useCallback(() => {
-    if (isMinimized) setIsMinimized(false);
-    setIsMaximized((value) => !value);
-  }, [isMinimized]);
+  }, [addCommand, isMinimized, restore, t]);
 
   const increaseFontScale = useCallback(() => {
     setFontScale((value) => clampFontScale(value + FONT_SCALE_STEP));

--- a/stores/window.store.ts
+++ b/stores/window.store.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { create } from "zustand";
+
+export type DockAnchor = { x: number; y: number };
+
+type WindowStore = {
+  isMinimized: boolean;
+  isMaximized: boolean;
+  dockAnchor: DockAnchor | null;
+  minimize: () => void;
+  restore: () => void;
+  toggleMinimize: () => void;
+  toggleMaximize: () => void;
+  setDockAnchor: (anchor: DockAnchor | null) => void;
+};
+
+export const useWindowStore = create<WindowStore>()((set) => ({
+  isMinimized: false,
+  isMaximized: false,
+  dockAnchor: null,
+  minimize: () => set({ isMinimized: true, isMaximized: false }),
+  restore: () => set({ isMinimized: false }),
+  toggleMinimize: () =>
+    set((state) => ({
+      isMinimized: !state.isMinimized,
+      isMaximized: state.isMinimized && state.isMaximized,
+    })),
+  toggleMaximize: () =>
+    set((state) => ({
+      isMaximized: !state.isMaximized,
+      isMinimized: false,
+    })),
+  setDockAnchor: (dockAnchor) => set({ dockAnchor }),
+}));

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -114,3 +114,66 @@ test.describe("Guestbook flow", () => {
     await expect(page.getByText(/guestbook/i).first()).toBeVisible();
   });
 });
+
+test.describe("Minimize to dock", () => {
+  /** The dock tile shares its label with the window's own yellow dot, which
+   * stays in the DOM while hidden — scope to the one outside the window. */
+  const dockTile = (page: Page): Locator =>
+    page.getByRole("button", { name: /restore terminal$/i }).last();
+
+  test("collapses the window into the dock and back", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await getReadyInput(page);
+
+    const windowStage = page.locator("main");
+    await expect(windowStage).toBeVisible();
+    await expect(dockTile(page)).toBeHidden();
+
+    await page.getByRole("button", { name: /minimize terminal/i }).click();
+
+    await expect(windowStage).toBeHidden();
+    await expect(windowStage).toHaveAttribute("aria-hidden", "true");
+    await expect(dockTile(page)).toBeVisible();
+
+    await dockTile(page).click();
+
+    await expect(windowStage).toBeVisible();
+    await expect(dockTile(page)).toBeHidden();
+  });
+
+  test("keeps a half-typed command through the round trip", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    const input = await getReadyInput(page);
+    await input.fill("about");
+
+    await page.getByRole("button", { name: /minimize terminal/i }).click();
+    await expect(page.locator("main")).toBeHidden();
+    await dockTile(page).click();
+
+    await expect(input).toHaveValue("about");
+  });
+
+  test("leaves the footer layout untouched once restored", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await getReadyInput(page);
+
+    const github = page.getByRole("link", { name: "GitHub", exact: true });
+    const before = await github.boundingBox();
+
+    await page.getByRole("button", { name: /minimize terminal/i }).click();
+    await expect(dockTile(page)).toBeVisible();
+    const during = await github.boundingBox();
+    expect(during?.x).toBeGreaterThan(before?.x ?? 0);
+
+    await dockTile(page).click();
+    await expect(dockTile(page)).toBeHidden();
+    expect(Math.round((await github.boundingBox())?.x ?? -1)).toBe(
+      Math.round(before?.x ?? -2),
+    );
+  });
+});

--- a/tests/test-utils.tsx
+++ b/tests/test-utils.tsx
@@ -8,6 +8,13 @@ const messages = {
       submit: "Run",
     },
     closeMessages: ["bye"],
+    trafficLights: {
+      close: "Close terminal",
+      minimize: "Minimize terminal",
+      restoreMinimize: "Restore terminal",
+      expand: "Expand terminal",
+      restoreExpand: "Restore terminal size",
+    },
   },
   Suggestions: {
     navigate: "Navigate",

--- a/tests/unit/components/WindowDock.test.tsx
+++ b/tests/unit/components/WindowDock.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { DockItem } from "@/components/DockItem";
+import { CommandsProvider } from "@/components/providers/CommandsProvider";
+import { TerminalProvider } from "@/components/providers/TerminalProvider";
+import { TrafficLights } from "@/components/TrafficLights";
+import { WindowStage } from "@/components/WindowStage";
+import { useWindowStore } from "@/stores/window.store";
+import { withIntl } from "../../test-utils";
+
+/** The layout in miniature: the window in one subtree, the dock in another. */
+function renderWindowAndDock() {
+  return render(
+    withIntl(
+      <CommandsProvider>
+        <TerminalProvider>
+          <WindowStage>
+            <TrafficLights />
+            <p>window content</p>
+          </WindowStage>
+        </TerminalProvider>
+        <DockItem />
+      </CommandsProvider>,
+    ),
+  );
+}
+
+describe("minimize to dock", () => {
+  beforeEach(() => {
+    useWindowStore.setState({ isMinimized: false, dockAnchor: null });
+  });
+
+  it("shows no dock tile while the window is open", () => {
+    renderWindowAndDock();
+
+    expect(
+      screen.queryByRole("button", { name: "Restore terminal" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the window and reveals the dock tile on minimize", async () => {
+    const user = userEvent.setup();
+    renderWindowAndDock();
+
+    await user.click(screen.getByRole("button", { name: "Minimize terminal" }));
+
+    expect(useWindowStore.getState().isMinimized).toBe(true);
+    expect(screen.getByText("window content").closest("main")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+    expect(
+      await screen.findByRole("button", { name: "Restore terminal" }),
+    ).toBeInTheDocument();
+  });
+
+  it("brings the window back when the dock tile is clicked", async () => {
+    const user = userEvent.setup();
+    renderWindowAndDock();
+
+    await user.click(screen.getByRole("button", { name: "Minimize terminal" }));
+    await user.click(
+      await screen.findByRole("button", { name: "Restore terminal" }),
+    );
+
+    expect(useWindowStore.getState().isMinimized).toBe(false);
+    expect(
+      screen.getByText("window content").closest("main"),
+    ).not.toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("keeps the window subtree mounted while minimized", async () => {
+    const user = userEvent.setup();
+    renderWindowAndDock();
+
+    await user.click(screen.getByRole("button", { name: "Minimize terminal" }));
+
+    expect(screen.getByText("window content")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/stores/window.store.test.ts
+++ b/tests/unit/stores/window.store.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useWindowStore } from "@/stores/window.store";
+
+describe("window store", () => {
+  beforeEach(() => {
+    useWindowStore.setState({
+      isMinimized: false,
+      isMaximized: false,
+      dockAnchor: null,
+    });
+  });
+
+  it("starts with the window open and no dock anchor", () => {
+    expect(useWindowStore.getState().isMinimized).toBe(false);
+    expect(useWindowStore.getState().dockAnchor).toBeNull();
+  });
+
+  it("minimizes and restores", () => {
+    useWindowStore.getState().minimize();
+    expect(useWindowStore.getState().isMinimized).toBe(true);
+
+    useWindowStore.getState().restore();
+    expect(useWindowStore.getState().isMinimized).toBe(false);
+  });
+
+  it("stays minimized when minimize is called twice", () => {
+    useWindowStore.getState().minimize();
+    useWindowStore.getState().minimize();
+    expect(useWindowStore.getState().isMinimized).toBe(true);
+  });
+
+  it("toggles both ways", () => {
+    useWindowStore.getState().toggleMinimize();
+    expect(useWindowStore.getState().isMinimized).toBe(true);
+
+    useWindowStore.getState().toggleMinimize();
+    expect(useWindowStore.getState().isMinimized).toBe(false);
+  });
+
+  it("drops maximized when the window collapses into the dock", () => {
+    useWindowStore.getState().toggleMaximize();
+    expect(useWindowStore.getState().isMaximized).toBe(true);
+
+    useWindowStore.getState().toggleMinimize();
+    expect(useWindowStore.getState().isMinimized).toBe(true);
+    expect(useWindowStore.getState().isMaximized).toBe(false);
+  });
+
+  it("restores a plain window when maximizing from the dock", () => {
+    useWindowStore.getState().minimize();
+
+    useWindowStore.getState().toggleMaximize();
+    expect(useWindowStore.getState().isMinimized).toBe(false);
+    expect(useWindowStore.getState().isMaximized).toBe(true);
+  });
+
+  it("does not bring maximized back when restoring from the dock", () => {
+    useWindowStore.getState().toggleMaximize();
+    useWindowStore.getState().toggleMinimize();
+    useWindowStore.getState().toggleMinimize();
+
+    expect(useWindowStore.getState().isMinimized).toBe(false);
+    expect(useWindowStore.getState().isMaximized).toBe(false);
+  });
+
+  it("is never both minimized and maximized", () => {
+    const s = useWindowStore.getState;
+    for (const step of [
+      s().toggleMaximize,
+      s().toggleMinimize,
+      s().minimize,
+      s().toggleMaximize,
+      s().toggleMinimize,
+    ]) {
+      step();
+      expect(s().isMinimized && s().isMaximized).toBe(false);
+    }
+  });
+
+  it("records and clears the dock anchor", () => {
+    useWindowStore.getState().setDockAnchor({ x: 120, y: 640 });
+    expect(useWindowStore.getState().dockAnchor).toEqual({ x: 120, y: 640 });
+
+    useWindowStore.getState().setDockAnchor(null);
+    expect(useWindowStore.getState().dockAnchor).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- The yellow traffic light now minimizes the **whole window** — logo and terminal together — into a dock tile in the footer, the way macOS minimizes, instead of collapsing the terminal to a 44px header bar.
- The window shrinks toward the tile and fades out, leaving the world map completely unobstructed; the tile carries the logo and a pinging indicator, and clicking it flies the window back out.
- Window chrome state moves into a small zustand store so the traffic lights and the dock — sibling subtrees with no common provider — can share it.

## Changes

### Features
- `stores/window.store.ts`: window chrome state outside React's tree. Owns the minimized/maximized mutual exclusion so callers can't drift into a window that is both. Not persisted — a reload hands you an open window.
- `components/WindowStage.tsx`: the collapse animation. Measures its own center against the dock the instant minimizing starts, then shrinks and translates toward it. Stays **mounted** behind `visibility: hidden` rather than unmounting, so a half-typed command, the scroll position and any manual resize survive the round trip.
- `components/DockItem.tsx`: the footer tile. The slot stays mounted at zero width so the collapsing window has something to aim at before the tile exists, and a negative right margin cancels the row's own gap while it is closed — the footer is pixel-identical when the window is open.
- `app/[locale]/page.tsx`, `components/Footer.tsx`: wire the stage around the page content and the tile into the footer.

### Refactors
- `hooks/useTerminalState.ts`: `isMinimized` and `isMaximized` both move to the store; both handlers reduce to plain store actions.
- `components/terminal/Terminal.tsx`, `TerminalBody.tsx`: drop the old collapse-to-a-header-bar styling, now dead since the whole window hides.

## Testing
- [x] `bun run test` — 366 unit tests pass (store invariants + minimize-to-dock round trip)
- [x] `bun run test:e2e` — 22 pass on **Chromium + Firefox**
- [x] `bun run typecheck` / `lint` / `format:check` — all clean
- [x] Verified in a real browser: tile lands at the exact anchor the collapse aims for; socials shift while the tile is out and return to their original position on restore; keystrokes cannot reach the hidden window (focus stays on `body`); reduced-motion still hides and restores cleanly.
- [x] Lighthouse before/after on identical production builds: Performance 71→71, Accessibility 100→100, Best Practices 100→100, SEO 92→92. **CLS stays 0.000** and LCP is unchanged within noise. Cost is +2.8 KB JS.

## Breaking Changes
None — the traffic light keeps its behaviour contract, and `useTerminalState`'s public API is unchanged.

## Commits
26c5989 test(window): cover minimize, restore and dock behaviour
3953434 refactor(terminal): move window chrome state into the window store
4de1c6d feat(window): collapse the window into a footer dock
